### PR TITLE
Prevent interleaving of messages

### DIFF
--- a/homekit/secure_http.py
+++ b/homekit/secure_http.py
@@ -15,6 +15,7 @@
 #
 
 import io
+import threading
 import http.client
 
 from homekit.chacha20poly1305 import chacha20_aead_encrypt, chacha20_aead_decrypt
@@ -55,6 +56,7 @@ class SecureHttp:
         self.c2a_key = c2a_key
         self.c2a_counter = 0
         self.a2c_counter = 0
+        self.lock = threading.Lock()
 
     def get(self, target):
         data = 'GET {tgt} HTTP/1.1\n\n'.format(tgt=target)
@@ -77,14 +79,15 @@ class SecureHttp:
         return self._handle_request(data)
 
     def _handle_request(self, data):
-        data = data.replace("\n", "\r\n")
-        assert len(data) < 1024
-        len_bytes = len(data).to_bytes(2, byteorder='little')
-        cnt_bytes = self.c2a_counter.to_bytes(8, byteorder='little')
-        self.c2a_counter += 1
-        ciper_and_mac = chacha20_aead_encrypt(len_bytes, self.c2a_key, cnt_bytes, bytes([0, 0, 0, 0]), data.encode())
-        self.sock.send(len_bytes + ciper_and_mac[0] + ciper_and_mac[1])
-        return self._handle_response()
+        with self.lock:
+            data = data.replace("\n", "\r\n")
+            assert len(data) < 1024
+            len_bytes = len(data).to_bytes(2, byteorder='little')
+            cnt_bytes = self.c2a_counter.to_bytes(8, byteorder='little')
+            self.c2a_counter += 1
+            ciper_and_mac = chacha20_aead_encrypt(len_bytes, self.c2a_key, cnt_bytes, bytes([0, 0, 0, 0]), data.encode())
+            self.sock.send(len_bytes + ciper_and_mac[0] + ciper_and_mac[1])
+            return self._handle_response()
 
     @staticmethod
     def _parse(chunked_data):


### PR DESCRIPTION
If we send a second command over a socket before the device has finished
handling the first, we may end up with two interleaved responses. We can
avoid that by preventing concurrent requests on the same socket.