### PR TITLE
More bluetooth work

### DIFF
--- a/homekit/controller/ble_implementation.py
+++ b/homekit/controller/ble_implementation.py
@@ -458,8 +458,8 @@ class Device(staging.gatt.gatt.Device):
 
         try:
             if not self.services:
-                for i in range(10):
                 logger.debug('waiting for services to be resolved')
+                for i in range(20):
                     if self.is_services_resolved():
                         break
                     time.sleep(1)

--- a/homekit/controller/ble_implementation.py
+++ b/homekit/controller/ble_implementation.py
@@ -559,9 +559,9 @@ class ServicesResolvingDevice(Device):
                 self.resolved_data['data'].append(s_data)
 
         logger.debug('data: %s', self.resolved_data)
-        logger.debug('disconnecting from device')
-        self.disconnect()
-        logger.debug('disconnected from device')
+        #logger.debug('disconnecting from device')
+        #self.disconnect()
+        #logger.debug('disconnected from device')
         self.manager.stop()
         logger.debug('manager stopped')
 

--- a/homekit/controller/ble_implementation.py
+++ b/homekit/controller/ble_implementation.py
@@ -266,6 +266,9 @@ class BleSession(object):
             time.sleep(1)
             logger.debug('reading characteristic')
             data = feature_char.read_value()
+            if not data and not self.device.is_connected():
+                raise RuntimeError('Read failed')
+
         resp_data = bytearray([b for b in data])
         logger.debug('read: %s', bytearray(resp_data).hex())
 

--- a/homekit/discover_ble.py
+++ b/homekit/discover_ble.py
@@ -19,7 +19,6 @@ import threading
 import time
 import logging
 from argparse import ArgumentParser
-import sys
 import os
 from homekit.model import Categories
 
@@ -122,7 +121,7 @@ class Device(gatt.Device):
 
     def __repr__(self):
         return 'BleDevice[mac_address="{}", name="{}"]'.format(self.mac_address, self.name)
- 
+
 
 class DeviceManager(gatt.DeviceManager):
 

--- a/homekit/discover_ble.py
+++ b/homekit/discover_ble.py
@@ -111,11 +111,19 @@ class Device(gatt.Device):
 
 class DeviceManager(gatt.DeviceManager):
 
+    discover_callback = None
+
     def make_device(self, mac_address):
         device = Device(mac_address=mac_address, manager=self)
         if not device.homekit_discovery_data:
             return
         self._manage_device(device)
+        if self.discover_callback:
+            self.discover_callback(device)
+
+    def start_discovery(self, callback=None):
+        self.discover_callback = callback
+        return gatt.DeviceManager.start_discovery(self)
 
 
 def discover(adapter, timeout=10):

--- a/homekit/discover_ble.py
+++ b/homekit/discover_ble.py
@@ -16,54 +16,35 @@
 #
 
 import threading
-import subprocess
 import time
 import logging
 from argparse import ArgumentParser
 import sys
 import os
-import struct
 from homekit.model import Categories
 
-# These constants are all taken from https://www.bluetooth.com/specifications/bluetooth-core-specification and are
-# defined on the pages mentioned.
-HCI_EVENT = 0x04  # page 2400
-
-LE_META = 0x3e  # page 1190
-
-LE_ADVERTISING_REPORT = 0x02  # page 1193
-
-EVENT_TYPE_CONNECTABLE_UNDIRECTED_ADVERTISING = 0x00  # page 1193
-EVENT_TYPE_NONCONNECTABLE_UNDIRECTED_ADVERTISING = 0x03  # page 1193
-EVENT_TYPE_SCAN_RESPONSE = 0x04  # page 1194
-
-devices = {}
+from staging import gatt
 
 
 class Killer(threading.Thread):
-    def __init__(self, timeout, process):
+
+    def __init__(self, manager, timeout):
         threading.Thread.__init__(self)
         self.timeout = timeout
-        self.process = process
+        self.manager = manager
 
     def run(self):
         time.sleep(self.timeout)
-        self.process.kill()
+        self.manager.stop()
 
 
 def parse_manufacturer_specific(input_data):
     logging.debug('manufacturer specific data: %s', input_data.hex())
 
-    # parse the manufacturer, this must be 0x4C 0x00 as defined on page 124 table 6-29
-    coid = input_data[:2]
-    input_data = input_data[2:]
-    if coid == b'\x4c\x00':
-        coid = 'apple'
-
     # the type must be 0x06 as defined on page 124 table 6-29
     ty = input_data[0]
     input_data = input_data[1:]
-    if coid == 'apple' and ty == 0x06:
+    if ty == 0x06:
         ty = 'HomeKit'
 
         ail = input_data[0]
@@ -98,180 +79,52 @@ def parse_manufacturer_specific(input_data):
         input_data = input_data[1:]
         if len(input_data) > 0:
             logging.debug('remaining data: %s', input_data.hex())
-        return {'manufacturer': coid, 'type': ty, 'sf': sf, 'deviceId': device_id, 'acid': acid,
+        return {'manufacturer': 'apple', 'type': ty, 'sf': sf, 'deviceId': device_id, 'acid': acid,
                 'gsn': gsn, 'cn': cn, 'cv': cv, 'category': Categories[int(acid)]}
 
-    return {'manufacturer': coid, 'type': ty}
+    return {'manufacturer': 'apple', 'type': ty}
 
 
-def parse_ble_meta_data(input_data):
-    total_length = input_data[0]
-    input_data = input_data[1:1 + total_length]
-    logging.debug('length %d data %s', total_length, input_data.hex())
+class Device(gatt.Device):
 
-    if total_length != len(input_data):
-        logging.error('length issue %d %d -- %s', total_length, len(input_data), input_data.hex())
-        return
+    homekit_discovery_data = None
 
-    if not input_data[0] == LE_ADVERTISING_REPORT:
-        logging.error('No Sub Event: LE Advertising Report %s', input_data.hex())
-        return
-    input_data = input_data[1:]
+    def __init__(self, *args, **kwargs):
+        gatt.Device.__init__(self, *args, **kwargs, managed=False)
 
-    if input_data[0] != 0x01:
-        # TODO: how does an advertising look if there are more than one reports?
-        logging.error('No Num Reports: %d', input_data[0], input_data.hex())
-        return
-    input_data = input_data[1:]
+        self.name = self._properties.Get('org.bluez.Device1', 'Alias')
 
-    # Bluetooth Core Spec 5.0 page 1193
-    if input_data[0] == EVENT_TYPE_CONNECTABLE_UNDIRECTED_ADVERTISING:
-        event_type = 'Connectable Undirected Advertising'
-    elif input_data[0] == EVENT_TYPE_NONCONNECTABLE_UNDIRECTED_ADVERTISING:
-        event_type = 'Non-Connectable Undirected Advertising'
-    elif input_data[0] == EVENT_TYPE_SCAN_RESPONSE:
-        event_type = 'Scan Response'
-    else:
-        logging.error('Unknown Event Type:', input_data[0], ' -- ', input_data.hex())
-        event_type = 'unknown'
-    input_data = input_data[1:]
+        mfr_data = self._properties.Get('org.bluez.Device1', 'ManufacturerData')
+        mfr_data = dict((int(k), bytes(bytearray(v))) for (k, v) in mfr_data.items())
 
-    # Bluetooth Core Spec 5.0 page 1194
-    if input_data[0] == 0x00:
-        # Peer Address Type: Public Device Address (0x00)
-        address_type = 'public'
-    elif input_data[0] == 0x01:
-        address_type = 'random'
-    else:
-        print('Unknown Address Type:', input_data[0], ' -- ', input_data.hex())
-        address_type = 'unknown'
-        # return
-    input_data = input_data[1:]
+        if 76 not in mfr_data:
+            return
 
-    # Bluetooth Core Spec 5.0 page 1194
-    mac = input_data[:6].hex().upper()
-    mac = mac[10:12] + ':' + mac[8:10] + ':' + mac[6:8] + ':' + mac[4:6] + ':' + mac[2:4] + ':' + mac[0:2]
-    if mac not in devices:
-        devices[mac] = {}
+        parsed = parse_manufacturer_specific(mfr_data[76])
 
-    devices[mac]['address_type'] = address_type
-    devices[mac]['event_type'] = event_type
-    input_data = input_data[6:]
+        if parsed['type'] != 'HomeKit':
+            return
 
-    # Bluetooth Core Spec 5.0 page 1194
-    data_length = input_data[0]
+        self.homekit_discovery_data = parsed
 
-    # Bluetooth Core Spec 5.0 page 1194
-    remaining_data = input_data[1 + data_length:]
-    rssi = struct.unpack('b', remaining_data)[0]
-    devices[mac]['rssi'] = rssi
-    logging.debug('rssi: %d', rssi)
+ 
 
-    input_data = input_data[1:1 + data_length]
+class DeviceManager(gatt.DeviceManager):
 
-    while len(input_data) > 0:
-        # the format of the advertising data is defined in Bluetooth Core Spec 5.0 page 2086
-        part_length = input_data[0]
-        input_data = input_data[1:]
-
-        part_type = input_data[0]
-        input_data = input_data[1:]
-
-        part_data = input_data[0:part_length - 1]
-        input_data = input_data[part_length - 1:]
-
-        # the part types are defined in https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile
-        if part_type == 1:
-            devices[mac]['Flags'] = part_data
-        elif part_type == 8:
-            devices[mac]['Short Device Name'] = part_data
-        elif part_type == 9:
-            devices[mac]['Device Name'] = part_data.decode('ascii')
-        elif part_type == 255:
-            devices[mac]['Manufacturer Specific'] = parse_manufacturer_specific(part_data)
-        else:
-            devices[mac][part_type] = part_data
-
-
-def which(program):
-    """
-    function to check if an executable is somewhere in the PATH and return it with full path.
-
-    taken from https://stackoverflow.com/a/377028
-    """
-
-    def is_exe(file):
-        return os.path.isfile(file) and os.access(file, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-    return None
+    def make_device(self, mac_address):
+        device = Device(mac_address=mac_address, manager=self)
+        if not device.homekit_discovery_data:
+            return
+        self._manage_device(device)
 
 
 def discover(adapter, timeout=10):
-    hciconfig = which('hciconfig')
-    hcitool = which('hcitool')
-    hcidump = which('hcidump')
+    manager = DeviceManager(adapter)
+    manager.start_discovery()
+    Killer(manager, timeout).start()
+    manager.run()
 
-    if not hciconfig:
-        print('hciconfig could not be found in the PATH!')
-        sys.exit(-1)
-
-    if not hcitool:
-        print('hcitool could not be found in the PATH!')
-        sys.exit(-1)
-
-    if not hcidump:
-        print('hcidump could not be found in the PATH!')
-        sys.exit(-1)
-
-    command = [hciconfig, adapter, 'up']
-    logging.debug('Executing \'%s\'', ' '.join(command))
-    p0 = subprocess.Popen(command, stdout=subprocess.PIPE)
-
-    command = [hcitool, '-i', adapter, 'lescan', '--duplicates']
-    logging.debug('Executing \'%s\'', ' '.join(command))
-    p0 = subprocess.Popen(command, stdout=subprocess.PIPE)
-    Killer(timeout, p0).start()
-
-    command = [hcidump, '-i', adapter, '--raw', '2>&1']
-    logging.debug('Executing \'%s\'', ' '.join(command))
-    p1 = subprocess.Popen(command, stdout=subprocess.PIPE)
-    Killer(timeout, p1).start()
-
-    data = None
-    # we have to parse the output of hcidump here: it looks like
-    # > 04 3E 2B 02 01 00 01 64 9F ED 22 D1 EB 1F 02 01 06 16 FF 4C
-    #   00 06 31 01 84 BF 32 C2 8F 04 0A 00 02 00 01 02 9E 5D 64 42
-    #   04 08 4B 6F 6F D7
-    # > ...
-    for line in p1.stdout:
-        # lines from hci dump starting with > (ASCII 62) mark a new package
-        if line[0] == 62:
-            # a new packet is started, so we handle the old packet's data now
-            if data:
-                data = data.decode('ascii')
-                data = bytes.fromhex(data.replace(' ', ''))
-                logging.debug('data %s', data.hex())
-                if data[0] == HCI_EVENT and data[1] == LE_META:
-                    parse_ble_meta_data(data[2:])
-            # data of the new packet, but without the starting '> ' and the ending line break
-            data = line[2:-2]
-        elif data is not None:
-            # we already have read at least a packet start and now add the following lines (ignoring space and line
-            # break in the beginning and end.
-            data = (data + line[1:-2])
-            raw = data
-
-    return devices
+    return manager._devices.values()
 
 
 if __name__ == '__main__':
@@ -297,29 +150,18 @@ if __name__ == '__main__':
 
     logging.debug('using adapter %s', args.adapter)
 
-    if os.getuid() != 0:
-        print('+------------------------------------------+')
-        print('| Must be run as root. Use sudo! See help. |')
-        print('+------------------------------------------+')
-        print()
-        arg_parser.print_help()
-        sys.exit(-1)
-
     devices = discover(args.adapter, args.timeout)
 
     print()
-    for mac in devices:
-        device = devices[mac]
-        if 'Manufacturer Specific' in device \
-                and 'type' in device['Manufacturer Specific'] \
-                and device['Manufacturer Specific']['type'] == 'HomeKit':
-            print('Name: {name}'.format(name=device['Device Name']))
-            print('MAC: {mac}'.format(mac=mac))
-            print('Configuration number (c#): {conf}'.format(conf=device['Manufacturer Specific']['cn']))
-            print('Device ID (id): {id}'.format(id=device['Manufacturer Specific']['deviceId']))
-            print('Compatible Version (cv): {cv}'.format(cv=device['Manufacturer Specific']['cv']))
-            print('State Number (s#): {sn}'.format(sn=device['Manufacturer Specific']['gsn']))
-            print('Status Flags (sf): {sf}'.format(sf=device['Manufacturer Specific']['sf']))
-            print('Category Identifier (ci): {c} (Id: {ci})'.format(c=device['Manufacturer Specific']['category'],
-                                                                    ci=device['Manufacturer Specific']['acid']))
-            print()
+    for device in devices:
+        data = device.homekit_discovery_data
+        print('Name: {name}'.format(name=device.name))
+        print('MAC: {mac}'.format(mac=device.mac_address))
+        print('Configuration number (c#): {conf}'.format(conf=data['cn']))
+        print('Device ID (id): {id}'.format(id=data['deviceId']))
+        print('Compatible Version (cv): {cv}'.format(cv=data['cv']))
+        print('State Number (s#): {sn}'.format(sn=data['gsn']))
+        print('Status Flags (sf): {sf}'.format(sf=data['sf']))
+        print('Category Identifier (ci): {c} (Id: {ci})'.format(c=data['category'],
+                                                                ci=data['acid']))
+        print()


### PR DESCRIPTION
The major change in this branch is to switch to bluez for discovery. This removes the dep on `hcitool` and `hcidump` and friends and doesn't add any dependencies beyond the dbus bluetooth code we already have. And this stack now works without root!

I also updated `put_characteristics` to use the characteristic cache, and both it and `get_characteristics` will drop the secure session if there are bluetooth errors. Future requests then start a new secure session, allowing some level of recovery. With this in place my bluetooth accessories are still functional in home-assistant after a night of running.

Had a few rare occurences where the service resolving was slower, so bumped the timeout for that.

Also switched from `logging.debug` which AIUI is using the root logger, to using a module level logger.

I didn't even leave a stray `print()` in this time! ;)