### PR TITLE
Fix for Xiaomi Aqara gateway

### DIFF
--- a/homekit/model/characteristics/characteristic_types.py
+++ b/homekit/model/characteristics/characteristic_types.py
@@ -246,8 +246,8 @@ class _CharacteristicsTypes(object):
         self._characteristics_rev = {self._characteristics[k]: k for k in self._characteristics.keys()}
 
     def __getitem__(self, item):
-        if item.upper() in self._characteristics:
-            return self._characteristics[item.upper()]
+        if item in self._characteristics:
+            return self._characteristics[item]
 
         if item in self._characteristics_rev:
             return self._characteristics_rev[item]

--- a/homekit/model/characteristics/characteristic_types.py
+++ b/homekit/model/characteristics/characteristic_types.py
@@ -246,6 +246,7 @@ class _CharacteristicsTypes(object):
         self._characteristics_rev = {self._characteristics[k]: k for k in self._characteristics.keys()}
 
     def __getitem__(self, item):
+        item = item.upper()
         if item in self._characteristics:
             return self._characteristics[item]
 
@@ -265,6 +266,7 @@ class _CharacteristicsTypes(object):
         :param uuid: the UUID in long form or the shortened version as defined in chapter 5.6.1 page 72.
         :return: the textual representation
         """
+        uuid = uuid.upper()
         orig_item = uuid
         if uuid.endswith(self.baseUUID):
             uuid = uuid.split('-', 1)[0]

--- a/homekit/model/characteristics/characteristic_types.py
+++ b/homekit/model/characteristics/characteristic_types.py
@@ -246,9 +246,8 @@ class _CharacteristicsTypes(object):
         self._characteristics_rev = {self._characteristics[k]: k for k in self._characteristics.keys()}
 
     def __getitem__(self, item):
-        item = item.upper()
-        if item in self._characteristics:
-            return self._characteristics[item]
+        if item.upper() in self._characteristics:
+            return self._characteristics[item.upper()]
 
         if item in self._characteristics_rev:
             return self._characteristics_rev[item]

--- a/homekit/model/services/service_types.py
+++ b/homekit/model/services/service_types.py
@@ -63,6 +63,7 @@ class _ServicesTypes(object):
         self._services_rev = {self._services[k]: k for k in self._services.keys()}
 
     def __getitem__(self, item):
+        item = item.upper()
         if item in self._services:
             return self._services[item]
 
@@ -73,6 +74,7 @@ class _ServicesTypes(object):
         return 'Unknown Service: {i}'.format(i=item)
 
     def get_short(self, item):
+        item = item.upper()
         orig_item = item
         if item.endswith(self.baseUUID):
             item = item.split('-', 1)[0]

--- a/homekit/model/services/service_types.py
+++ b/homekit/model/services/service_types.py
@@ -63,8 +63,8 @@ class _ServicesTypes(object):
         self._services_rev = {self._services[k]: k for k in self._services.keys()}
 
     def __getitem__(self, item):
-        if item.upper() in self._services:
-            return self._services[item.upper()]
+        if item in self._services:
+            return self._services[item]
 
         if item in self._services_rev:
             return self._services_rev[item]

--- a/homekit/model/services/service_types.py
+++ b/homekit/model/services/service_types.py
@@ -63,9 +63,8 @@ class _ServicesTypes(object):
         self._services_rev = {self._services[k]: k for k in self._services.keys()}
 
     def __getitem__(self, item):
-        item = item.upper()
-        if item in self._services:
-            return self._services[item]
+        if item.upper() in self._services:
+            return self._services[item.upper()]
 
         if item in self._services_rev:
             return self._services_rev[item]

--- a/tests/characteristicsTypes_test.py
+++ b/tests/characteristicsTypes_test.py
@@ -48,4 +48,5 @@ class TestCharacteristicsTypes(unittest.TestCase):
         self.assertEqual(CharacteristicsTypes.get_short(CharacteristicsTypes.DOOR_STATE_TARGET), 'door-state.target')
         self.assertEqual(CharacteristicsTypes.get_short(CharacteristicsTypes.AIR_PURIFIER_STATE_CURRENT),
                          'air-purifier.state.current')
-        self.assertEqual(CharacteristicsTypes.get_short('1a'), 'Unknown Characteristic 1a')
+        #self.assertEqual(CharacteristicsTypes.get_short('1a'), 'Unknown Characteristic 1a')
+        self.assertEqual(CharacteristicsTypes.get_short('1a'), 'lock-management.auto-secure-timeout')


### PR DESCRIPTION
This gateway sends all his characteristics and services using lowercase letters.
Thus your library cannot identify some of information.
Quick fix to make uppercase-comparisons despite input being lowercase.