### PR TITLE
Fix build error openssl cryptography

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
     - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
     - sudo apt-get update
     - pip install coveralls
     - wget http://launchpadlibrarian.net/400343104/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
-    - dpkg -i libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
+    - sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
     - wget http://launchpadlibrarian.net/367327834/openssl_1.1.0g-2ubuntu4_amd64.deb
-    - dpkg -i openssl_1.1.0g-2ubuntu4_amd64.deb
+    - sudo dpkg -i openssl_1.1.0g-2ubuntu4_amd64.deb
 script: coverage run -m unittest -v
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
 before_install:
     - sudo apt-get update
     - pip install coveralls
+    - wget http://launchpadlibrarian.net/400343104/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
+    - dpkg -i libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
+    - wget http://launchpadlibrarian.net/367327834/openssl_1.1.0g-2ubuntu4_amd64.deb
+    - dpkg -i openssl_1.1.0g-2ubuntu4_amd64.deb
 script: coverage run -m unittest -v
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ python:
     - "3.5"
     - "3.6"
 before_install:
-    - echo "-----------------------------------------"
-    - openssl version
-    - sudo dpkg -l
-    - echo "-----------------------------------------"
+    # update openssl to a version that is sufficient for cryptography 2.6 (openssl 1.1 is required since)
     - wget http://launchpadlibrarian.net/400343104/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
     - sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
     - wget http://launchpadlibrarian.net/367327834/openssl_1.1.0g-2ubuntu4_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,19 @@ python:
     - "3.5"
     - "3.6"
 before_install:
-    - sudo apt-get update
-    - pip install coveralls
+    - echo "-----------------------------------------"
+    - openssl version
+    - sudo dpkg -l
+    - echo "-----------------------------------------"
     - wget http://launchpadlibrarian.net/400343104/libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
     - sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4.3_amd64.deb
     - wget http://launchpadlibrarian.net/367327834/openssl_1.1.0g-2ubuntu4_amd64.deb
     - sudo dpkg -i openssl_1.1.0g-2ubuntu4_amd64.deb
+    - echo "-----------------------------------------"
+    - openssl version
+    - echo "-----------------------------------------"
+    - sudo apt-get update
+    - pip install coveralls
 script: coverage run -m unittest -v
 after_success:
     - coveralls


### PR DESCRIPTION
This will re-enable builds on travis.ci as test platform under linux. The openssl version was too old to work with cryptography 2.6 (release on  Feb 27, 2019, see https://cryptography.io/en/latest/changelog/#v2-6)