### PR TITLE
#104 - support pairing devices with displays

### DIFF
--- a/homekit/controller/controller.py
+++ b/homekit/controller/controller.py
@@ -323,6 +323,33 @@ class Controller(object):
         :raises MaxPeersError: if the device cannot accept an additional pairing
         :raises UnavailableError: on wrong pin
         """
+        finish_pairing = self.start_pairing(alias, accessory_id)
+        return finish_pairing(pin)
+
+    def start_pairing(self, alias, accessory_id):
+        """
+        This starts a pairing attempt with the IP accessory identified by its id.
+        It returns a callable (finish_pairing) which you must call with the pairing pin.
+
+        Accessories can be found via the discover method. The id field is the accessory's id for the second parameter.
+
+        The required pin is either printed on the accessory or displayed. Must be a string of the form 'XXX-YY-ZZZ'.
+
+        Important: no automatic saving of the pairing data is performed. If you don't do this, the information is lost
+            and you have to reset the accessory!
+
+        :param alias: the alias for the accessory in the controllers data
+        :param accessory_id: the accessory's id
+        :param pin: function to return the accessory's pin
+        :raises AccessoryNotFoundError: if no accessory with the given id can be found
+        :raises AlreadyPairedError: if the alias was already used
+        :raises UnavailableError: if the device is already paired
+        :raises MaxTriesError: if the device received more than 100 unsuccessful attempts
+        :raises BusyError: if a parallel pairing is ongoing
+        :raises AuthenticationError: if the verification of the device's SRP proof fails
+        :raises MaxPeersError: if the device cannot accept an additional pairing
+        :raises UnavailableError: on wrong pin
+        """
         if not IP_TRANSPORT_SUPPORTED:
             raise TransportNotSupportedError('IP')
         if alias in self.pairings:
@@ -332,16 +359,25 @@ class Controller(object):
         if connection_data is None:
             raise AccessoryNotFoundError('Cannot find accessory with id "{i}".'.format(i=accessory_id))
         conn = HomeKitHTTPConnection(connection_data['ip'], port=connection_data['port'])
+
         try:
             write_fun = create_ip_pair_setup_write(conn)
             salt, pub_key = perform_pair_setup_part1(write_fun)
-            pairing = perform_pair_setup_part2(pin(), str(uuid.uuid4()), write_fun, salt, pub_key)
-        finally:
+        except Exception:
             conn.close()
-        pairing['AccessoryIP'] = connection_data['ip']
-        pairing['AccessoryPort'] = connection_data['port']
-        pairing['Connection'] = 'IP'
-        self.pairings[alias] = IpPairing(pairing)
+            raise
+
+        def finish_pairing(pin):
+            try:
+                pairing = perform_pair_setup_part2(pin, str(uuid.uuid4()), write_fun, salt, pub_key)
+            finally:
+                conn.close()
+            pairing['AccessoryIP'] = connection_data['ip']
+            pairing['AccessoryPort'] = connection_data['port']
+            pairing['Connection'] = 'IP'
+            self.pairings[alias] = IpPairing(pairing)
+
+        return finish_pairing
 
     def perform_pairing_ble(self, alias, accessory_mac, pin, adapter='hci0'):
         """
@@ -357,6 +393,26 @@ class Controller(object):
         :param alias: the alias for the accessory in the controllers data
         :param accessory_mac: the accessory's mac address
         :param pin: function to return the accessory's pin
+        :param adapter: the bluetooth adapter to be used (defaults to hci0)
+        # TODO add raised exceptions
+        """
+        finish_pairing = self.start_pairing_ble(alias, accessory_mac, adapter)
+        return finish_pairing(pin)
+
+    def start_pairing_ble(self, alias, accessory_mac, adapter='hci0'):
+        """
+        This starts a pairing attempt with the Bluetooth LE accessory identified by its mac address.
+        It returns a callable (finish_pairing) which you must call with the pairing pin.
+
+        Accessories can be found via the discover method. The mac field is the accessory's mac for the second parameter.
+
+        The required pin is either printed on the accessory or displayed. Must be a string of the form 'XXX-YY-ZZZ'.
+
+        Important: no automatic saving of the pairing data is performed. If you don't do this, the information is lost
+            and you have to reset the accessory!
+
+        :param alias: the alias for the accessory in the controllers data
+        :param accessory_mac: the accessory's mac address
         :param adapter: the bluetooth adapter to be used (defaults to hci0)
         # TODO add raised exceptions
         """
@@ -379,12 +435,16 @@ class Controller(object):
 
         write_fun = create_ble_pair_setup_write(pair_setup_char, pair_setup_char_id)
         salt, pub_key = perform_pair_setup_part1(write_fun)
-        pairing = perform_pair_setup_part2(pin(), str(uuid.uuid4()), write_fun, salt, pub_key)
 
-        pairing['AccessoryMAC'] = accessory_mac
-        pairing['Connection'] = 'BLE'
+        def finish_pairing(pin):
+            pairing = perform_pair_setup_part2(pin, str(uuid.uuid4()), write_fun, salt, pub_key)
 
-        self.pairings[alias] = BlePairing(pairing, adapter)
+            pairing['AccessoryMAC'] = accessory_mac
+            pairing['Connection'] = 'BLE'
+
+            self.pairings[alias] = BlePairing(pairing, adapter)
+
+        return finish_pairing
 
     def remove_pairing(self, alias):
         """

--- a/homekit/pair.py
+++ b/homekit/pair.py
@@ -74,7 +74,8 @@ if __name__ == '__main__':
         pin_function = pin_from_keyboard()
 
     try:
-        controller.perform_pairing(args.alias, args.device, pin_function)
+        finish_pairing = controller.start_pairing(args.alias, args.device)
+        finish_pairing(pin_function())
         pairing = controller.get_pairings()[args.alias]
         pairing.list_accessories_and_characteristics()
         controller.save_data(args.file)

--- a/homekit/pair_ble.py
+++ b/homekit/pair_ble.py
@@ -22,13 +22,14 @@ import logging
 
 from homekit.controller import Controller
 from homekit.log_support import setup_logging, add_log_arguments
+from homekit.pair import pin_from_parameter, pin_from_keyboard
 
 
 def setup_args_parser():
     parser = argparse.ArgumentParser(description='HomeKit BLE pairing app')
     parser.add_argument('-m', action='store', required=True, dest='mac',
                         help='HomeKit Device MAC (use discover to get it)')
-    parser.add_argument('-p', action='store', required=True, dest='pin', help='HomeKit configuration code')
+    parser.add_argument('-p', action='store', required=False, dest='pin', help='HomeKit configuration code')
     parser.add_argument('-f', action='store', required=True, dest='file', help='HomeKit pairing data file')
     parser.add_argument('-a', action='store', required=True, dest='alias', help='alias for the pairing')
     parser.add_argument('--adapter', action='store', dest='adapter', default='hci0',
@@ -56,9 +57,14 @@ if __name__ == '__main__':
         print('"{a}" is a already known alias'.format(a=args.alias))
         sys.exit(-1)
 
+    if args.pin:
+        pin_function = pin_from_parameter(args.pin)
+    else:
+        pin_function = pin_from_keyboard()
+
     try:
         logging.debug('start pairing')
-        controller.perform_pairing_ble(args.alias, args.mac, args.pin, args.adapter)
+        controller.perform_pairing_ble(args.alias, args.mac, pin_function, args.adapter)
         pairing = controller.get_pairings()[args.alias]
         pairing.list_accessories_and_characteristics()
         controller.save_data(args.file)

--- a/homekit/pair_ble.py
+++ b/homekit/pair_ble.py
@@ -64,7 +64,8 @@ if __name__ == '__main__':
 
     try:
         logging.debug('start pairing')
-        controller.perform_pairing_ble(args.alias, args.mac, pin_function, args.adapter)
+        finish_pairing = controller.start_pairing_ble(args.alias, args.mac, args.adapter)
+        finish_pairing(pin_function())
         pairing = controller.get_pairings()[args.alias]
         pairing.list_accessories_and_characteristics()
         controller.save_data(args.file)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,21 @@
+#
+# Copyright 2018 Joachim Lusiardi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def pin_returner(pin):
+    def tmp():
+        return pin
+    return tmp


### PR DESCRIPTION
I found your branch for #104 and made some changes to get it working with what i'm doing in HASS.

The first approach blocked the executing thread until the pin function returns a value. This wouldn't work in HASS because its async and there will be a pause until a pin is submitted. It does hav background threads for sync code but we can't block a thread for an unbound amount of time as they are limited and it would involve weird threading code (maybe a threading.Event?) to get the pin from the web code on the main thread into the pairing thread.

I contemplated using the new `perform_pair_setup_part2` directly, but there is a lot of code in perform_pairing / perform_pairing_ble that I didn't want to duplicate.

My new new approach initiates pairing then returns a callable. This is a closure so captures all the objects and variables it needs to work automatically. This can then be stored against a config flow object in HASS (effectively like storing it in an in memory "session" so it persists between requests). You call that with a pin when the user enters one to finish the pairing.

Relevant HASS changes is [here](https://github.com/Jc2k/home-assistant/commit/384c77b04de1f1d9023e9d760569b52f545e8d6d).

