### PR TITLE
#117 Factor out parse_discovery_properties helper

### DIFF
--- a/homekit/zeroconf_impl/__init__.py
+++ b/homekit/zeroconf_impl/__init__.py
@@ -109,6 +109,13 @@ def discover_homekit_devices(max_seconds=10):
 
 
 def decode_discovery_properties(props):
+    """
+    This method decodes unicode bytes in _hap._tcp Bonjour TXT record keys to python strings.
+
+    :params: a dictionary of key/value TXT records from Bonjour discovery. These are assumed
+    to be bytes type.
+    :return: A dictionary of key/value TXT records from Bonjour discovery. These are now str.
+    """
     out = {}
     for k, v in props.items():
         out[k.decode('utf-8')] = v.decode('utf-8')
@@ -116,6 +123,17 @@ def decode_discovery_properties(props):
 
 
 def parse_discovery_properties(props):
+    """
+    This method normalizes and parses _hap._tcp Bonjour TXT record keys.
+
+    This is done automatically if you are using the discovery features built in to the library. If you are
+    integrating into an existing system it may already do its own Bonjour discovery. In that case you can
+    call this function to normalize the properties it has discovered.
+
+    :param props: a dictionary of key/value TXT records from doing Bonjour discovery. These should be
+    decoded as strings already. Byte data should be decoded with decode_discovery_properties.
+    :return: A dictionary contained the parsed and normalized data.
+    """
     d = {}
 
     # stuff taken from the Bonjour TXT record (see table 5-7 on page 69)

--- a/homekit/zeroconf_impl/__init__.py
+++ b/homekit/zeroconf_impl/__init__.py
@@ -68,7 +68,7 @@ def get_from_properties(props, key, default=None, case_sensitive=True):
         tmp_key = key.lower()
 
     if tmp_key in tmp_props:
-        return tmp_props[tmp_key].decode()
+        return tmp_props[tmp_key]
     else:
         if default:
             return str(default)
@@ -95,7 +95,9 @@ def discover_homekit_devices(max_seconds=10):
             'port': info.port
         }
 
-        d.update(parse_discovery_properties(info.properties))
+        d.update(parse_discovery_properties(decode_discovery_properties(
+            info.properties
+        )))
 
         if 'c#' not in d or 'md' not in d:
             continue
@@ -106,15 +108,22 @@ def discover_homekit_devices(max_seconds=10):
     return tmp
 
 
+def decode_discovery_properties(props):
+    out = {}
+    for k, v in props.items():
+        out[k.decode('utf-8')] = v.decode('utf-8')
+    return out
+
+
 def parse_discovery_properties(props):
     d = {}
 
     # stuff taken from the Bonjour TXT record (see table 5-7 on page 69)
-    conf_number = get_from_properties(props, b'c#', case_sensitive=False)
+    conf_number = get_from_properties(props, 'c#', case_sensitive=False)
     if conf_number:
         d['c#'] = conf_number
 
-    ff = get_from_properties(props, b'ff', case_sensitive=False)
+    ff = get_from_properties(props, 'ff', case_sensitive=False)
     if ff:
         flags = int(ff)
     else:
@@ -122,30 +131,30 @@ def parse_discovery_properties(props):
     d['ff'] = flags
     d['flags'] = FeatureFlags[flags]
 
-    id = get_from_properties(props, b'id', case_sensitive=False)
+    id = get_from_properties(props, 'id', case_sensitive=False)
     if id:
         d['id'] = id
 
-    md = get_from_properties(props, b'md', case_sensitive=False)
+    md = get_from_properties(props, 'md', case_sensitive=False)
     if md:
         d['md'] = md
 
-    pv = get_from_properties(props, b'pv', case_sensitive=False, default='1.0')
+    pv = get_from_properties(props, 'pv', case_sensitive=False, default='1.0')
     if pv:
         d['pv'] = pv
 
-    s = get_from_properties(props, b's#', case_sensitive=False)
+    s = get_from_properties(props, 's#', case_sensitive=False)
     if s:
         d['s#'] = s
 
-    sf = get_from_properties(props, b'sf', case_sensitive=False)
+    sf = get_from_properties(props, 'sf', case_sensitive=False)
     if sf:
         d['sf'] = sf
         d['statusflags'] = IpStatusFlags[int(sf)]
 
-    ci = get_from_properties(props, b'ci', case_sensitive=False)
+    ci = get_from_properties(props, 'ci', case_sensitive=False)
     if ci:
-        category = props[b'ci'].decode()
+        category = props['ci']
         d['ci'] = category
         d['category'] = Categories[int(category)]
 

--- a/homekit/zeroconf_impl/__init__.py
+++ b/homekit/zeroconf_impl/__init__.py
@@ -95,57 +95,61 @@ def discover_homekit_devices(max_seconds=10):
             'port': info.port
         }
 
-        props = info.properties
+        d.update(parse_discovery_properties(info.properties))
 
-        # stuff taken from the Bonjour TXT record (see table 5-7 on page 69)
-        conf_number = get_from_properties(props, b'c#', case_sensitive=False)
-        if conf_number:
-            d['c#'] = conf_number
-        else:
+        if 'c#' not in d or 'md' not in d:
             continue
 
-        ff = get_from_properties(props, b'ff', case_sensitive=False)
-        if ff:
-            flags = int(ff)
-        else:
-            flags = 0
-        d['ff'] = flags
-        d['flags'] = FeatureFlags[flags]
-
-        id = get_from_properties(props, b'id', case_sensitive=False)
-        if id:
-            d['id'] = id
-
-        md = get_from_properties(props, b'md', case_sensitive=False)
-        if md:
-            d['md'] = md
-        else:
-            continue
-
-        pv = get_from_properties(props, b'pv', case_sensitive=False, default='1.0')
-        if pv:
-            d['pv'] = pv
-
-        s = get_from_properties(props, b's#', case_sensitive=False)
-        if s:
-            d['s#'] = s
-
-        sf = get_from_properties(props, b'sf', case_sensitive=False)
-        if sf:
-            d['sf'] = sf
-        d['statusflags'] = IpStatusFlags[int(sf)]
-
-        ci = get_from_properties(props, b'ci', case_sensitive=False)
-        if ci:
-            category = info.properties[b'ci'].decode()
-            d['ci'] = category
-            d['category'] = Categories[int(category)]
-
-        # append device, it has all data
         tmp.append(d)
 
     zeroconf.close()
     return tmp
+
+
+def parse_discovery_properties(props):
+    d = {}
+
+    # stuff taken from the Bonjour TXT record (see table 5-7 on page 69)
+    conf_number = get_from_properties(props, b'c#', case_sensitive=False)
+    if conf_number:
+        d['c#'] = conf_number
+
+    ff = get_from_properties(props, b'ff', case_sensitive=False)
+    if ff:
+        flags = int(ff)
+    else:
+        flags = 0
+    d['ff'] = flags
+    d['flags'] = FeatureFlags[flags]
+
+    id = get_from_properties(props, b'id', case_sensitive=False)
+    if id:
+        d['id'] = id
+
+    md = get_from_properties(props, b'md', case_sensitive=False)
+    if md:
+        d['md'] = md
+
+    pv = get_from_properties(props, b'pv', case_sensitive=False, default='1.0')
+    if pv:
+        d['pv'] = pv
+
+    s = get_from_properties(props, b's#', case_sensitive=False)
+    if s:
+        d['s#'] = s
+
+    sf = get_from_properties(props, b'sf', case_sensitive=False)
+    if sf:
+        d['sf'] = sf
+        d['statusflags'] = IpStatusFlags[int(sf)]
+
+    ci = get_from_properties(props, b'ci', case_sensitive=False)
+    if ci:
+        category = props[b'ci'].decode()
+        d['ci'] = category
+        d['category'] = Categories[int(category)]
+
+    return d
 
 
 def find_device_ip_and_port(device_id: str, max_seconds=10):

--- a/tests/zeroconf_test.py
+++ b/tests/zeroconf_test.py
@@ -103,33 +103,33 @@ class TestZeroconf(unittest.TestCase):
         self.assertIsNone(test_device)
 
     def test_existing_key(self):
-        props = {b'c#': b'259'}
-        val = get_from_properties(props, b'c#')
+        props = {'c#': '259'}
+        val = get_from_properties(props, 'c#')
         self.assertEqual('259', val)
 
     def test_non_existing_key_no_default(self):
-        props = {b'c#': b'259'}
-        val = get_from_properties(props, b's#')
+        props = {'c#': '259'}
+        val = get_from_properties(props, 's#')
         self.assertEqual(None, val)
 
     def test_non_existing_key_case_insensitive(self):
-        props = {b'C#': b'259', b'heLLo': b'World'}
-        val = get_from_properties(props, b'c#')
+        props = {'C#': '259', 'heLLo': 'World'}
+        val = get_from_properties(props, 'c#')
         self.assertEqual(None, val)
-        val = get_from_properties(props, b'c#', case_sensitive=True)
+        val = get_from_properties(props, 'c#', case_sensitive=True)
         self.assertEqual(None, val)
-        val = get_from_properties(props, b'c#', case_sensitive=False)
+        val = get_from_properties(props, 'c#', case_sensitive=False)
         self.assertEqual('259', val)
 
-        val = get_from_properties(props, b'HEllo', case_sensitive=False)
+        val = get_from_properties(props, 'HEllo', case_sensitive=False)
         self.assertEqual('World', val)
 
     def test_non_existing_key_with_default(self):
-        props = {b'c#': b'259'}
-        val = get_from_properties(props, b's#', default='1')
+        props = {'c#': '259'}
+        val = get_from_properties(props, 's#', default='1')
         self.assertEqual('1', val)
 
     def test_non_existing_key_with_default_non_string(self):
-        props = {b'c#': b'259'}
-        val = get_from_properties(props, b's#', default=1)
+        props = {'c#': '259'}
+        val = get_from_properties(props, 's#', default=1)
         self.assertEqual('1', val)


### PR DESCRIPTION
This implements #117.

Home Assistant uses the netdisco library to do discovery of IP accessories. This is a wrapper around the same zeroconf library that homekit_python uses. I need to continue using netdisco to get good integration with the config entry/configurator UI. But I want to use the existing homekit_python code to do things like case insensitivity handling and for getting converting strings to be e.g. a `FeatureFlag` instance.

This PR does that.

This should be a no-op change for the existing homekit_python cli tools. They should be unaware that anything has changed. However there is now a method I can use from HASS:

```python
from homekit.zeroconf_impl import parse_discovery_properties
parse_discovery_properties(discovery_info['properties'])
```

One annoying detail is that HASS actually decodes the properties to proper strings before passing them to me, so i have tweaked the code so there is a form for proper strings (HASS style):

```python
parse_discovery_properties({
    'c#': '1',
    ...
})
```

and for byte strings (existing homekit_python style):

```python
parse_discovery_properties(
    decode_discovery_properties({
        b'c#': b'1',
        ...
    })
)
```

This means the HASS discovery code will benefit from fixes made in homekit_python :-)