### PR TITLE
Regression tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
     'TestServerData', 'BleCharacteristicFormatsTest', 'BleCharacteristicUnitsTest', 'CharacteristicTypesTest',
     'TestBLEController', 'TestChacha20poly1305', 'TestCharacteristicsTypes', 'TestController', 'TestControllerIpPaired',
     'TestControllerIpUnpaired', 'TestHttpResponse', 'TestHttpStatusCodes', 'TestMfrData', 'TestSrp', 'TestTLV',
-    'TestZeroconf', 'TestBLEPairing', 'TestServiceTypes', 'TestSecureHttp'
+    'TestZeroconf', 'TestBLEPairing', 'TestServiceTypes', 'TestSecureHttp', 'TestHTTPPairing', 'TestSecureSession'
 ]
 
 from tests.bleCharacteristicFormats_test import BleCharacteristicFormatsTest
@@ -31,6 +31,7 @@ from tests.characteristicsTypes_test import TestCharacteristicsTypes
 from tests.controller_test import TestControllerIpPaired, TestControllerIpUnpaired, TestController
 from tests.httpStatusCodes_test import TestHttpStatusCodes
 from tests.http_response_test import TestHttpResponse
+from tests.regression_test import TestHTTPPairing, TestSecureSession
 from tests.secure_http_test import TestSecureHttp
 from tests.serverdata_test import TestServerData
 from tests.serviceTypes_test import TestServiceTypes

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -1,0 +1,83 @@
+"""
+This module is for regression tests.
+
+This is where we have identified something that breaks a HomeKit accessory
+certified by Apple because our implementation of the spec is different to
+Apple's. If your change trips a test in this module it is likely you will 
+break support for a device that currently works.
+
+We strive to comply with the HAP spec wherever possible, and where
+possible we aim to do what an iOS device would do.
+"""
+
+import unittest
+from unittest import mock
+
+from homekit.http_impl.secure_http import SecureHttp
+
+
+class TestHTTPPairing(unittest.TestCase):
+
+    """
+    Communication failures in the pairing stage.
+
+    These types of problem generally involve comparing a working and
+    non-working device via WireShark.
+    """
+
+    def test_pairing_doesnt_add_extra_headers(self):
+        """
+        The tado internet bridge will fail if a pairing request has
+        extraneous headers like `Accept-Encoding`.
+
+        https://github.com/home-assistant/home-assistant/issues/16971
+        https://github.com/jlusiardi/homekit_python/pull/130
+        """
+
+
+class TestSecureSession(unittest.TestCase):
+
+    """
+    Communication failures of HTTP secure session layer.
+
+    To debug these its often easiest to modify demoserver.py to dump
+    data as it decrypts it, then compare an iOS device to homekit_python.
+    """
+
+    def test_requests_have_host_header(self):
+        """
+        The tado internet bridge will fail if a secure session request
+        doesn't have a Host header.
+
+        https://github.com/home-assistant/home-assistant/issues/16971
+        https://github.com/jlusiardi/homekit_python/pull/130
+        """
+
+        session = mock.Mock()
+        session.pairing_data = {
+            'AccessoryIP': '192.168.1.2:8000',
+            'AccesoryPort': 8080,
+        }
+        secure_http = SecureHttp(session)
+
+        with mock.patch.object(session, '_handle_request') as handle_req:
+            secure_http.get('/characteristics')
+            assert b'\nHost: 192.168.1.2:8080\n' in handle_req.call_args[0][0]
+
+            secure_http.post('/characteristics')
+            assert b'\nHost: 192.168.1.2:8080\n' in handle_req.call_args[0][0]
+
+            secure_http.put('/characteristics')
+            assert b'\nHost: 192.168.1.2:8080\n' in handle_req.call_args[0][0]
+
+    def test_requests_only_send_params_for_true_case(self):
+        """
+        The tado internet bridge will fail if a GET request has what it
+        considers to be unexpected request parameters.
+
+        An iPhone client sends requests like `/characteristics?id=1.10`.
+        It doesn't transmit `ev=0` or any other falsies.
+
+        https://github.com/home-assistant/home-assistant/issues/16971
+        https://github.com/jlusiardi/homekit_python/pull/132
+        """


### PR DESCRIPTION
We talked about how we can avoid breaking devices that we know work today. We came to the conclusion that right now the best we could do was start start building a set of regression tests for devices we know that didn't work and then we got to work. This won't stop us breaking support for devices which always worked, but we don't know what they are so there isn't much we can do for them.

Here are an initial set based on my recent tado related changes.

They should hopefully give a bit of a warning if you change some code that might reintroduce an old behaviour.

I think going forward the project policy should be that if a devices relies on a low level detail thats not covered by the spec then it should have a test added here. Any PR that touches this file should get extra scrutiny if its changing an existing test, and it probably should never remove a test.