### PR TITLE
Fix 138 adapter not suitable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,4 +115,4 @@ ENV/
 MANIFEST
 Tests.md
 /ip_env
-/*_env
+*.swp

--- a/homekit/controller/ble_impl/device.py
+++ b/homekit/controller/ble_impl/device.py
@@ -122,6 +122,9 @@ class DeviceManager(gatt.DeviceManager):
 
     def __init__(self, adapter):
         super().__init__(adapter)
+
+        # save the old power state of the Bluetooth LE adapter to be able to restore it after
+        # the program ends
         atexit.register(self.cleanup)
         self.old_powerstate = self.is_adapter_powered
         self.adapter = adapter
@@ -133,6 +136,7 @@ class DeviceManager(gatt.DeviceManager):
         return self.Device(mac_address=mac_address, manager=self)
 
     def cleanup(self):
+        # restore the old power state
         if not self.old_powerstate:
             logger.debug('restoring power state adapter "%s"' % self.adapter)
             self.is_adapter_powered = self.old_powerstate

--- a/homekit/controller/ble_impl/discovery.py
+++ b/homekit/controller/ble_impl/discovery.py
@@ -47,7 +47,13 @@ class DiscoveryDeviceManager(DeviceManager):
         function will be called every time a new device is discovered.
         """
         self.discover_callback = callback
-        return super().start_discovery()
+        powerstate = self.is_adapter_powered
+        if not powerstate:
+            self.is_adapter_powered = True
+        tmp = super().start_discovery()
+        if not powerstate:
+            self.is_adapter_powered = powerstate
+        return tmp
 
     def devices(self):
         # The standard implementation of devices causes a fresh of the dbus

--- a/homekit/controller/ble_impl/discovery.py
+++ b/homekit/controller/ble_impl/discovery.py
@@ -47,12 +47,7 @@ class DiscoveryDeviceManager(DeviceManager):
         function will be called every time a new device is discovered.
         """
         self.discover_callback = callback
-        powerstate = self.is_adapter_powered
-        if not powerstate:
-            self.is_adapter_powered = True
         tmp = super().start_discovery()
-        if not powerstate:
-            self.is_adapter_powered = powerstate
         return tmp
 
     def devices(self):

--- a/homekit/controller/ble_impl/discovery.py
+++ b/homekit/controller/ble_impl/discovery.py
@@ -47,8 +47,7 @@ class DiscoveryDeviceManager(DeviceManager):
         function will be called every time a new device is discovered.
         """
         self.discover_callback = callback
-        tmp = super().start_discovery()
-        return tmp
+        return super().start_discovery()
 
     def devices(self):
         # The standard implementation of devices causes a fresh of the dbus

--- a/homekit/controller/ble_impl/gatt.py
+++ b/homekit/controller/ble_impl/gatt.py
@@ -125,8 +125,9 @@ class DeviceManager(gatt.DeviceManager):
         if not hci_adapter_exists(adapter_name):
             raise BluetoothAdapterError('Adapter "{a}" does not exist!'.format(a=adapter_name))
         if not hci_adapter_exists_and_supports_bluetooth_le(adapter_name):
-            #self.logger.warning('Adapter "{a}" seems not to support Bluetooth LE'.format(a=adapter_name))
-            print('Adapter "{a}" seems not to support Bluetooth LE, the command might not function properly!'.format(a=adapter_name))
+            # self.logger.warning('Adapter "{a}" seems not to support Bluetooth LE'.format(a=adapter_name))
+            print('Adapter "{a}" seems not to support Bluetooth LE, the command might not function properly!'
+                  .format(a=adapter_name))
         super().__init__(adapter_name)
 
     def set_timeout(self, timeout):

--- a/homekit/controller/ble_impl/gatt.py
+++ b/homekit/controller/ble_impl/gatt.py
@@ -125,7 +125,6 @@ class DeviceManager(gatt.DeviceManager):
         if not hci_adapter_exists(adapter_name):
             raise BluetoothAdapterError('Adapter "{a}" does not exist!'.format(a=adapter_name))
         if not hci_adapter_exists_and_supports_bluetooth_le(adapter_name):
-            # self.logger.warning('Adapter "{a}" seems not to support Bluetooth LE'.format(a=adapter_name))
             print('Adapter "{a}" seems not to support Bluetooth LE, the command might not function properly!'
                   .format(a=adapter_name))
         super().__init__(adapter_name)

--- a/homekit/controller/ble_impl/gatt.py
+++ b/homekit/controller/ble_impl/gatt.py
@@ -34,13 +34,13 @@ the classes in this module.
 """
 
 import re
-
+import logging
 import dbus
 import gatt
 from gatt.gatt_linux import _error_from_dbus_error
 from gi.repository import GObject
 
-from homekit.controller.ble_impl.tools import hci_adapter_exists_and_supports_bluetooth_le
+from homekit.controller.ble_impl.tools import hci_adapter_exists_and_supports_bluetooth_le, hci_adapter_exists
 from homekit.exceptions import BluetoothAdapterError
 
 
@@ -121,8 +121,12 @@ class DeviceManager(gatt.DeviceManager):
         :param adapter_name: the name of the adapter (defaults to hci0)
         :raises BluetoothAdapterError: if either the adapter does not exist or lacks appropriate capabilities
         """
+        self.logger = logging.getLogger('homekit.controller.ble')
+        if not hci_adapter_exists(adapter_name):
+            raise BluetoothAdapterError('Adapter "{a}" does not exist!'.format(a=adapter_name))
         if not hci_adapter_exists_and_supports_bluetooth_le(adapter_name):
-            raise BluetoothAdapterError('Adapter "{a}" does not suit our needs'.format(a=adapter_name))
+            #self.logger.warning('Adapter "{a}" seems not to support Bluetooth LE'.format(a=adapter_name))
+            print('Adapter "{a}" seems not to support Bluetooth LE, the command might not function properly!'.format(a=adapter_name))
         super().__init__(adapter_name)
 
     def set_timeout(self, timeout):

--- a/homekit/controller/ble_impl/tools.py
+++ b/homekit/controller/ble_impl/tools.py
@@ -8,8 +8,8 @@ from homekit.model import Categories
 
 def _get_hci_adapter(adapter_name):
     """
-    Returns the DBus interfaces of the given adapter (if the adapter exists). 
-    
+    Returns the DBus interfaces of the given adapter (if the adapter exists).
+
     :param adapter_name: the bluetooth adapter to be returned (hci0, hci1, ...)
     :return: the existing interfaces into DBus, None if the adapter does not exist.
     """

--- a/homekit/identify.py
+++ b/homekit/identify.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             sys.exit(-1)
     elif args.mac:
         try:
-            controller.identify_ble(args.mac)
+            controller.identify_ble(args.mac, args.adapter)
         except Exception as e:
             print(e)
             logging.debug(e, exc_info=True)


### PR DESCRIPTION
This will also fix an error in `homekit/identify.py` which ignored the adapter setting if trying to identify BLE accessories.