### PR TITLE
WIP: Prototype for #151

### DIFF
--- a/homekit/controller/ip_implementation.py
+++ b/homekit/controller/ip_implementation.py
@@ -266,44 +266,6 @@ class IpPairing(AbstractPairing):
             return data
         return {}
 
-    def get_events(self, characteristics, callback_fun, max_events=-1, max_seconds=-1):
-        """
-        This function is called to register for events on characteristics and receive them. Each time events are
-        received a call back function is invoked. By that the caller gets information about the events.
-
-        The characteristics are identified via their proper accessory id (aid) and instance id (iid).
-
-        The call back function takes a list of 3-tupels of aid, iid and the value, e.g.:
-          [(1, 9, 26.1), (1, 10, 30.5)]
-
-        If the input contains characteristics without the event permission or any other error, the function will return
-        a dict containing tupels of aid and iid for each requested characteristic with error. Those who would have
-        worked are not in the result.
-
-        :param characteristics: a list of 2-tupels of accessory id (aid) and instance id (iid)
-        :param callback_fun: a function that is called each time events were recieved
-        :param max_events: number of reported events, default value -1 means unlimited
-        :param max_seconds: number of seconds to wait for events, default value -1 means unlimited
-        :return: a dict mapping 2-tupels of aid and iid to dicts with status and description, e.g.
-                 {(1, 37): {'description': 'Notification is not supported for characteristic.', 'status': -70406}}
-        """
-        bus = self.get_message_bus()
-
-        bus.subscribe(characteristics)
-
-        start_time = time.time()
-        for event_count, event in enumerate(bus):
-            if max_events >= 0 and event_count >= max_events:
-                break
-            if max_seconds >= 0 and (time.time() - start_time) >= max_seconds:
-                break
-            tmp = []
-            for (aid, iid), char in event.items():
-                tmp.append(aid, iid, char.get('value'))
-            callback_fun(tmp)
-
-        return {}
-
     def get_message_bus(self):
         if not self.session:
             self.session = IpSession(self.pairing_data)

--- a/homekit/controller/ip_implementation.py
+++ b/homekit/controller/ip_implementation.py
@@ -53,6 +53,7 @@ class IpPairing(AbstractPairing):
         """
         if self.session:
             self.session.close()
+            self.session = None
 
     def _get_pairing_data(self):
         """
@@ -290,8 +291,11 @@ class IpPairing(AbstractPairing):
 
         bus.subscribe(characteristics)
 
+        start_time = time.time()
         for event_count, event in enumerate(bus):
             if max_events >= 0 and event_count >= max_events:
+                break
+            if max_seconds >= 0 and (time.time() - start_time) >= max_seconds:
                 break
             tmp = []
             for (aid, iid), char in event.items():
@@ -360,11 +364,6 @@ class IpPairing(AbstractPairing):
         data = TLV.decode_bytes(data)
         # TODO handle the response properly
         self.session.close()
-    
-    def close(self):
-        if self.session:
-            self.session.close()
-            self.session = None
 
 
 class IpMessageBus(object):
@@ -443,7 +442,6 @@ class IpMessageBus(object):
         except (AccessoryDisconnectedError, EncryptionError):
             self.pairing.close()
             raise
-
 
     def put_characteristics(self, characteristics, do_conversion=False, field='value'):
         """

--- a/homekit/controller/tools.py
+++ b/homekit/controller/tools.py
@@ -130,6 +130,7 @@ class AbstractPairing(abc.ABC):
         bus = self.get_message_bus()
 
         bus.subscribe(characteristics)
+        bus.get_characteristics(characteristics)
 
         start_time = time.time()
         for event_count, event in enumerate(bus):

--- a/homekit/controller/tools.py
+++ b/homekit/controller/tools.py
@@ -139,12 +139,12 @@ class AbstractPairing(abc.ABC):
                 break
             tmp = []
             for (aid, iid), char in event.items():
-                tmp.append(aid, iid, char.get('value'))
+                tmp.append((aid, iid, char.get('value')))
             callback_fun(tmp)
 
         return {}
     
-    @abs.abstractmethod
+    @abc.abstractmethod
     def get_message_bus(self):
         raise NotImplementedError(self.get_message_bus)
 

--- a/homekit/get_events.py
+++ b/homekit/get_events.py
@@ -69,6 +69,7 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         sys.exit(-1)
     except Exception as e:
+        raise
         print(e)
         logging.debug(e, exc_info=True)
         sys.exit(-1)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setuptools.setup(
     name='homekit',
     packages=setuptools.find_packages(exclude=['tests']),
-    version='0.15.0',
+    version='0.14.0',
     description='Python code to interface HomeKit Accessories and Controllers',
     author='Joachim Lusiardi',
     author_email='pypi@lusiardi.de',

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -105,15 +105,16 @@ class TestSecureSession(unittest.TestCase):
         secure_http = SecureHttp(session)
 
         with mock.patch.object(secure_http, '_handle_request') as handle_req:
-            secure_http.get('/characteristics')
-            print(handle_req.call_args[0][0])
-            assert '\r\nHost: 192.168.1.2:8080\r\n' in handle_req.call_args[0][0].decode()
+            with mock.patch.object(secure_http, '_read_response'):
+                secure_http.get('/characteristics')
+                print(handle_req.call_args[0][0])
+                assert '\r\nHost: 192.168.1.2:8080\r\n' in handle_req.call_args[0][0].decode()
 
-            secure_http.post('/characteristics', b'')
-            assert '\r\nHost: 192.168.1.2:8080\r\n' in handle_req.call_args[0][0].decode()
+                secure_http.post('/characteristics', b'')
+                assert '\r\nHost: 192.168.1.2:8080\r\n' in handle_req.call_args[0][0].decode()
 
-            secure_http.put('/characteristics', b'')
-            assert '\r\nHost: 192.168.1.2:8080\r\n' in handle_req.call_args[0][0].decode()
+                secure_http.put('/characteristics', b'')
+                assert '\r\nHost: 192.168.1.2:8080\r\n' in handle_req.call_args[0][0].decode()
 
     def test_requests_only_send_params_for_true_case(self):
         """


### PR DESCRIPTION
This is a quick prototype for #151 option 2. This provides a mechanism to allow HAP events on the same TCP stream as calls that have request/reply semantics like get_characteristics (which is what Apple does) by treating the replies as events.

This:

 * Avoids races where the event stream reads our response for a request/response method like get_characteristics or get_characteristic reads an event instead of its result
 * Fixes compatibility with HomeBridge which has an exacerbated form of the above (unsolicited events without even subscribing).
 * Allows us to implement controllers that are as rich as the Apple ones without needing the accessories to handle double the number of TCP streams small underpowered devices have to support
 * Incidentally provides a nice way for my HASS code to share code paths for pull and push.

The final PR should contain documentation that warns not to use the main API when subscribing to events.

I don't think i can safely implement option 1 in #151 without porting to asyncio or similar.

This is added as a new API to keep the old API and keep this as a non breaking change.

The code needs some cleanups - and there are some opportunities to reduce code duplication - but i wanted to form some consensus around the approach first.

The TL;DR for the changes are:

 * Make some _nowait() variants of the low level HTTP API. These make the HTTP requests but do not wait for a return.
 * Add a new `get_message_bus()`. This returns an object that can be iterated over to receive the events. It also has `get_characteristics`, `put_characteristics`, `subscribe` and `unsubscribe` methods that use the new `_nowait()` variants under the hood
 * Reimplements `get_event` on top of this API.

If you like the direction this is going in I will polish it - get rid of code duplication, add tests, fix docstrings, add warnings etc.