### PR TITLE
Add support for events to accessory server

### DIFF
--- a/homekit/accessoryserver.py
+++ b/homekit/accessoryserver.py
@@ -393,7 +393,7 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             try:
                 self.orig_wfile.write(out_data)
                 self.orig_wfile.flush()
-            except ValueError as e:
+            except ValueError:
                 raise DisconnectedControllerError()
 
     def handle_one_request(self):

--- a/homekit/exceptions.py
+++ b/homekit/exceptions.py
@@ -254,3 +254,8 @@ class TransportNotSupportedError(HomeKitException):
     def __init__(self, transport):
         Exception.__init__(self,
                            'Transport {t} not supported. See setup.py for required dependencies.'.format(t=transport))
+
+
+class DisconnectedControllerError(HomeKitException):
+    def __init__(self):
+        Exception.__init__(self, 'Controller has passed away')


### PR DESCRIPTION
This is the first step towards #51, but arguably not a complete solution. I have pulled it out of #154 so it can be reviewed in isolation. It doesn't have tests on its own (but there are tests that make use of this in #154).

If you have 2 active connections open to an accessory then a put_characteristic on connection 1 will now trigger events on connection but not its own connection (and vice versa).

This refactors the part of handle_one_request that writes a HTTP response to the wire out into its own function and ensures that only one task can write to the socket at once (otherwise there is a race when there are multiple tasks encrypting and writing to the network).

Then there is a write_event helper on the request handler that writes a single HTTP Event Response to the wire. There is a variant of this on the HTTPServer that can write an event to all active connections.

Right now events are only triggered from put_characteristic HTTP handlers. If you were writing an accessory with homekit_python you could manually call write_event on the HTTPServer when you are recording a change. To fully close #51 we should probably integrate a bit better than this, though.

To see it working I run a demoserver.py in on terminal, pair with it in another then do:

```python
python -m homekit.get_events -f test.json -a test -c 1.10
```

Then in a third terminal

```python
python -m homekit.put_characteristic -f test.json -a test -c 1.10 true
```