### PR TITLE
Refactor get_session_keys to be a generator based state machine

### DIFF
--- a/homekit/controller/ble_impl/__init__.py
+++ b/homekit/controller/ble_impl/__init__.py
@@ -481,6 +481,7 @@ class BleSession(object):
                 request, expected = state_machine.send(response)
             except StopIteration as result:
                 self.c2a_key, self.a2c_key = result.value
+                break
 
         logger.debug('pair_verified, keys: \n\t\tc2a: %s\n\t\ta2c: %s', self.c2a_key.hex(), self.a2c_key.hex())
 

--- a/homekit/controller/ble_impl/__init__.py
+++ b/homekit/controller/ble_impl/__init__.py
@@ -471,7 +471,7 @@ class BleSession(object):
             # TODO Have exception here
             sys.exit(-1)
 
-        write_fun = create_ble_pair_setup_write(pair_verify_char, pair_verify_char_info['iid'])
+        write_fun = create_ble_pair_verify_write(pair_verify_char, pair_verify_char_info['iid'])
         state_machine = get_session_keys(self.pairing_data)
 
         request, expected = state_machine.send(None)
@@ -612,11 +612,10 @@ def find_characteristic_by_uuid(device, service_uuid, char_uuid):
 def create_ble_pair_setup_write(characteristic, characteristic_id):
     def write(request, expected):
         # TODO document me
-        body = TLV.encode_list(request)
-        logger.debug('entering write function %s', TLV.to_string(TLV.decode_bytes(body)))
+        logger.debug('entering write function %s', TLV.to_string(TLV.decode_bytes(request)))
         request_tlv = TLV.encode_list([
             (TLV.kTLVHAPParamParamReturnResponse, bytearray(b'\x01')),
-            (TLV.kTLVHAPParamValue, body)
+            (TLV.kTLVHAPParamValue, request)
         ])
         transaction_id = random.randrange(0, 255)
         data = bytearray([0x00, HapBleOpCodes.CHAR_WRITE, transaction_id])
@@ -650,6 +649,17 @@ def create_ble_pair_setup_write(characteristic, characteristic_id):
         result = TLV.decode_bytes(resp_tlv[0][1], expected)
         logger.debug('leaving write function %s', TLV.to_string(result))
         return result
+
+    return write
+
+
+def create_ble_pair_verify_write(characteristic, characteristic_id):
+    # This is a temporary wrapper until the pairing functions are also migrated to
+    # the new state machine approach
+    pair_setup_write = create_ble_pair_setup_write(characteristic, characteristic_id)
+
+    def write(request, expected):
+        return pair_setup_write(TLV.encode_list(request), expected)
 
     return write
 


### PR DESCRIPTION
This will allow me to drop the `get_session_keys` function from [here](https://github.com/jlusiardi/homekit_python/pull/154/files#diff-9558b6cc6b18531fa6a8252aa2da27acR222) and use the same function for both the sync and non sync code paths.

The idea is to seperate the data exchanges involved in `get_session_keys` from the network/ble transports. The state machine just takes a TLV input and gives a TLV output, it is 'pure' and side effect free and only operates on data. The invoker is responsible for the actual I/O bit. This means we can use the same logic for async and sync code paths.

If we can get an approach we are happy with here there will be a very similar PR for the pairing state machine.

This code could be further simplified - I think ultimately we can refactor away the create_write_function functions as this approach isn't passing callables around. But that can be a seperate PR to keep things small and easy to review.