### PR TITLE
Tweak HttpResponse class for use with async clients

### DIFF
--- a/homekit/http_impl/response.py
+++ b/homekit/http_impl/response.py
@@ -92,7 +92,15 @@ class HttpResponse(object):
             pos = self._raw_response.find(b'\r\n')
 
         if self._state == HttpResponse.STATE_BODY and self._content_length > 0:
-            self.body = self._raw_response
+            remaining = self._content_length - len(self.body)
+            self.body += self._raw_response[:remaining]
+            self._raw_response = self._raw_response[remaining:]
+
+        if self.is_read_completely():
+            # Whatever is left in the buffer is part of the next request
+            return self._raw_response
+
+        return bytearray()
 
     def read(self):
         """


### PR DESCRIPTION
In my asyncio branch i end up copying the whole of HttpResponse class. I did this so the PR didn't contain lots of changes to the sync code. But this is actually a fairly small change we can review in isolation, so if we review it now it will make the aioclient branch 133 lines of code smaller and easier to review!

The aio client uses asyncio.Protocol and this means the network stack calls us when data is received, rather than us pulling (and blocking on) data from the network stack. This means we don't control how much data we get handed - it could be 2 complete `EVENT/1.0` responses. This PR just tweaks the parser so we can get back the data that wasn't consumed by the parser, allowing it to be fed into the next instance of HTTPResponse.

It doesn't change the ABI for the existing code - the existing code can just ignore the return value of parse.
