### PR TITLE
Use pytest to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ before_install:
     - ./.travis/install.sh
 script:
     - flake8 homekit
-    - coverage run -m unittest -v
+    - coverage run -m pytest tests/
 after_success:
     - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ gatt
 cryptography>=2.5
 coverage
 flake8
+pytest

--- a/requirements_osx.txt
+++ b/requirements_osx.txt
@@ -4,3 +4,4 @@ ed25519
 cryptography>=2.5
 coverage
 flake8
+pytest


### PR DESCRIPTION
Thought it might make sense to do this in a seperate PR to keep any discussion about it out of the way of the aio client.

pytest is my go to test runner, even if i'm sticking to vanilla unittest tests. I prefer how it captures test results and presents log output and stdout output alongside detailed traceback reports for each test failure. I like how it has helpers like `--pdb` to drop you into a debugger on a failing test. I like how it can run larger test suits in parallel. And its fixture system is a lot better than `setUp` and `setUpClass` - you can make a function that sets up an accessory server and then use it in any test without having to subclass a unittest class:

```python
@pytest.fixture
def accessoryserver():
    # DO SETUP HERE
    yield myaccessoryserver
    # DO CLEANUP HERE


def test_accessory_pairing(accessoryserver):
    # pytest has automatically run an accessory server for us and past it in as an argument
    pass
```

And fixtures can use fixtures - so you could have a fixture that setup an accessory server and a fixture that depended on it that injected a pre-prepared pairing state. They can also have scope - global, module, scope, function (kind of like `setUp` vs `setUpClass`).