### PR TITLE
Convert perform_pair_setup_part* to be state machines

### DIFF
--- a/homekit/controller/ble_impl/__init__.py
+++ b/homekit/controller/ble_impl/__init__.py
@@ -613,10 +613,11 @@ def find_characteristic_by_uuid(device, service_uuid, char_uuid):
 def create_ble_pair_setup_write(characteristic, characteristic_id):
     def write(request, expected):
         # TODO document me
-        logger.debug('entering write function %s', TLV.to_string(TLV.decode_bytes(request)))
+        body = TLV.encode_list(request)
+        logger.debug('entering write function %s', TLV.to_string(TLV.decode_bytes(body)))
         request_tlv = TLV.encode_list([
             (TLV.kTLVHAPParamParamReturnResponse, bytearray(b'\x01')),
-            (TLV.kTLVHAPParamValue, request)
+            (TLV.kTLVHAPParamValue, body)
         ])
         transaction_id = random.randrange(0, 255)
         data = bytearray([0x00, HapBleOpCodes.CHAR_WRITE, transaction_id])
@@ -650,17 +651,6 @@ def create_ble_pair_setup_write(characteristic, characteristic_id):
         result = TLV.decode_bytes(resp_tlv[0][1], expected)
         logger.debug('leaving write function %s', TLV.to_string(result))
         return result
-
-    return write
-
-
-def create_ble_pair_verify_write(characteristic, characteristic_id):
-    # This is a temporary wrapper until the pairing functions are also migrated to
-    # the new state machine approach
-    pair_setup_write = create_ble_pair_setup_write(characteristic, characteristic_id)
-
-    def write(request, expected):
-        return pair_setup_write(TLV.encode_list(request), expected)
 
     return write
 

--- a/homekit/controller/ble_impl/__init__.py
+++ b/homekit/controller/ble_impl/__init__.py
@@ -471,7 +471,7 @@ class BleSession(object):
             # TODO Have exception here
             sys.exit(-1)
 
-        write_fun = create_ble_pair_verify_write(pair_verify_char, pair_verify_char_info['iid'])
+        write_fun = create_ble_pair_setup_write(pair_verify_char, pair_verify_char_info['iid'])
         state_machine = get_session_keys(self.pairing_data)
 
         request, expected = state_machine.send(None)


### PR DESCRIPTION
As promised here is the other half of #161. The `perform_pair_setup_part*` functions are now 'pure' state machines - they don't do the IO themselves, and this means we can reuse them with the async client in #154. When this lands i will be able to completely rm `homekit/aio/controller/ip/crypto.py` from that branch.

(And this does eliminate `create_ble_pair_verify_write` again).