### PR TITLE
Fix incorrect __all__ addition

### DIFF
--- a/homekit/__init__.py
+++ b/homekit/__init__.py
@@ -36,4 +36,4 @@ if IP_TRANSPORT_SUPPORTED:
     # TODO: change import and let it be imported from its specific file
     from homekit.accessoryserver import AccessoryServer  # noqa: F401
 
-    __all__ += 'AccessoryServer'
+    __all__.append('AccessoryServer')


### PR DESCRIPTION
Nobody must have been using this...

```
>>> homekit.__all__
['Controller', ..., 'UnpairedError', 'A', 'c', 'c', 'e', 's', 's', 'o', 'r', 'y', 'S', 'e', 'r', 'v', 'e', 'r']
```