### PR TITLE
remove outdated comments

### DIFF
--- a/homekit/controller/controller.py
+++ b/homekit/controller/controller.py
@@ -539,7 +539,6 @@ class Controller(object):
             if not IP_TRANSPORT_SUPPORTED:
                 raise TransportNotSupportedError('IP')
             session = IpSession(pairing_data)
-            # decode is required because post needs a string representation
             response = session.post('/pairings', request_tlv)
             session.close()
             data = response.read()

--- a/homekit/controller/ip_implementation.py
+++ b/homekit/controller/ip_implementation.py
@@ -398,7 +398,6 @@ class IpPairing(AbstractPairing):
             (TLV.kTLVType_Permissions, permissions)
         ])
 
-        # decode is required because post needs a string representation
         response = self.session.sec_http.post('/pairings', request_tlv)
         data = response.read()
         data = TLV.decode_bytes(data)


### PR DESCRIPTION
We took out the .decode() but forgot to remove the comments.
https://github.com/jlusiardi/homekit_python/commit/d05839a2cd3737090a890d570626d49f2a0500ef