### PR TITLE
Add Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: python
 matrix:
     include:
-        - os: linux
-          dist: xenial
-          python: 3.5
-        - os: linux
-          dist: xenial
-          python: 3.6
-        - os: linux
-          dist: xenial
-          python: 3.7
-        - os: osx
-          language: generic
-          env: PYTHON=3.5.6
+#        - os: linux
+#          dist: xenial
+#          python: 3.5
+#        - os: linux
+#          dist: xenial
+#          python: 3.6
+#        - os: linux
+#          dist: xenial
+#          python: 3.7
+#        - os: osx
+#          language: generic
+#          env: PYTHON=3.5.6
+        - os: windows
+          language: sh
+          env: PY=py
 
 before_install:
     - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ script:
     - ${FLAKE8} homekit
     - ${FLAKE8} tests
     - ${FLAKE8} *.py
-    - ${COVERAGE} run -m pytest tests/
+    - ${COVERAGE} run -m pytest -s tests/
 after_success:
     - ${COVERALLS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ matrix:
 before_install:
     - ./.travis/install.sh
 script:
-    - ${FLAKE8} homekit
+    - /c/Python38/Scripts/flake8.exe homekit
     - ${FLAKE8} tests
     - ${FLAKE8} *.py
-    - ${COVERAGE} run -m pytest tests/
+    - /c/Python38/Scripts/coverage.exe run -m pytest tests/
 after_success:
-    - ${COVERALLS}
+    - /c/Python38/Scripts/coveralls.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: python
 matrix:
     include:
-#        - os: linux
-#          dist: xenial
-#          python: 3.5
+        - os: linux
+          dist: xenial
+          python: 3.5
+          env:
+            FLAKE8=flake8
+            COVERAGE=coverage
+            COVERALLS=coveralls
 #        - os: linux
 #          dist: xenial
 #          python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,18 @@ matrix:
 #          env: PYTHON=3.5.6
         - os: windows
           language: sh
-          env: PY=py
+          env:
+            PY=py
+            FLAKE8=flake8.exe
+            COVERAGE=coverage.exe
+            COVERALLS=coveralls.exe
 
 before_install:
     - ./.travis/install.sh
 script:
-    - flake8 homekit
-    - flake8 tests
-    - flake8 *.py
-    - coverage run -m pytest tests/
+    - ${FLAKE8} homekit
+    - ${FLAKE8} tests
+    - ${FLAKE8} *.py
+    - ${COVERAGE} run -m pytest tests/
 after_success:
-    - coveralls
+    - ${COVERALLS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,27 @@ matrix:
             FLAKE8=flake8
             COVERAGE=coverage
             COVERALLS=coveralls
-#        - os: linux
-#          dist: xenial
-#          python: 3.6
-#        - os: linux
-#          dist: xenial
-#          python: 3.7
-#        - os: osx
-#          language: generic
-#          env: PYTHON=3.5.6
+        - os: linux
+          dist: xenial
+          python: 3.6
+          env:
+            FLAKE8=flake8
+            COVERAGE=coverage
+            COVERALLS=coveralls
+        - os: linux
+          dist: xenial
+          python: 3.7
+          env:
+            FLAKE8=flake8
+            COVERAGE=coverage
+            COVERALLS=coveralls
+        - os: osx
+          language: generic
+          env:
+            PYTHON=3.5.6
+            FLAKE8=flake8
+            COVERAGE=coverage
+            COVERALLS=coveralls
         - os: windows
           language: sh
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,16 @@ matrix:
           language: sh
           env:
             PY=py
-            FLAKE8=flake8.exe
-            COVERAGE=coverage.exe
-            COVERALLS=coveralls.exe
+            FLAKE8=/c/Python38/Scripts/flake8.exe
+            COVERAGE=/c/Python38/Scripts/coverage.exe
+            COVERALLS=/c/Python38/Scripts/coveralls.exe
 
 before_install:
     - ./.travis/install.sh
 script:
-    - /c/Python38/Scripts/flake8.exe homekit
+    - ${FLAKE8} homekit
     - ${FLAKE8} tests
     - ${FLAKE8} *.py
-    - /c/Python38/Scripts/coverage.exe run -m pytest tests/
+    - ${COVERAGE} run -m pytest tests/
 after_success:
-    - /c/Python38/Scripts/coveralls.exe
+    - ${COVERALLS}

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -43,4 +43,5 @@ if [ "$TRAVIS_OS_NAME" == "windows" ]; then
     echo $PATH
     pwd
     ls -hal
+    ls -hal /c/Python38/Scripts
 fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -38,5 +38,5 @@ if [ "$TRAVIS_OS_NAME" == "windows" ]; then
     export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
     py --version
     pip3 --version
-    pip3 install -r requirements.txt
+    pip3 install -r requirements_windows.txt
 fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -32,3 +32,11 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     pip3 install -r requirements_osx.txt
     pip3 install coveralls
 fi
+
+if [ "$TRAVIS_OS_NAME" == "windows" ]; then
+    choco install python3 --params "/Python38:C:\Python38"
+    export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+    py --version
+    pip3 --version
+    pip3 install -r requirements.txt
+fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -40,4 +40,7 @@ if [ "$TRAVIS_OS_NAME" == "windows" ]; then
     pip3 --version
     pip3 install -r requirements_windows.txt
     pip3 install coveralls flake8
+    echo $PATH
+    pwd
+    ls -hal
 fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -40,8 +40,4 @@ if [ "$TRAVIS_OS_NAME" == "windows" ]; then
     pip3 --version
     pip3 install -r requirements_windows.txt
     pip3 install coveralls flake8
-    echo $PATH
-    pwd
-    ls -hal
-    ls -hal /c/Python38/Scripts
 fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -39,4 +39,5 @@ if [ "$TRAVIS_OS_NAME" == "windows" ]; then
     py --version
     pip3 --version
     pip3 install -r requirements_windows.txt
+    pip3 install coveralls flake8
 fi

--- a/homekit/accessoryserver.py
+++ b/homekit/accessoryserver.py
@@ -59,11 +59,11 @@ class AccessoryServerData:
             with open(data_file, 'r') as input_file:
                 self.data = json.load(input_file)
         except PermissionError:
-            raise ConfigLoadingError('Could not open "{f}" due to missing permissions'.format(f=input_file))
+            raise ConfigLoadingError('Could not open "{f}" due to missing permissions'.format(f=data_file))
         except JSONDecodeError:
-            raise ConfigLoadingError('Cannot parse "{f}" as JSON file'.format(f=input_file))
+            raise ConfigLoadingError('Cannot parse "{f}" as JSON file'.format(f=data_file))
         except FileNotFoundError:
-            raise ConfigLoadingError('Could not open "{f}" because it does not exist'.format(f=input_file))
+            raise ConfigLoadingError('Could not open "{f}" because it does not exist'.format(f=data_file))
 
         self.check()
 

--- a/homekit/crypto/srp.py
+++ b/homekit/crypto/srp.py
@@ -60,6 +60,9 @@ E0FD108E4B82D120A93AD2CAFFFFFFFFFFFFFFFF''', 16)
 
         :return: the key as an integer
         """
+        # see
+        #  - https://github.com/jlusiardi/homekit_python/issues/185#issuecomment-616344895 and
+        #  - https://cryptography.io/en/latest/random-numbers/
         return int.from_bytes(os.urandom(16), byteorder="big")
 
     def _calculate_k(self) -> int:
@@ -115,6 +118,7 @@ class SrpClient(Srp):
     """
     Implements all functions that are required to simulate an iOS HomeKit controller
     """
+
     def __init__(self, username: str, password: str):
         Srp.__init__(self)
         self.username = username
@@ -196,6 +200,7 @@ class SrpServer(Srp):
     """
     Implements all functions that are required to simulate an iOS HomeKit accessory
     """
+
     def __init__(self, username, password):
         Srp.__init__(self)
         self.username = username
@@ -210,7 +215,9 @@ class SrpServer(Srp):
 
     @staticmethod
     def _create_salt() -> int:
-        # generate random salt
+        # see
+        #  - https://github.com/jlusiardi/homekit_python/issues/185#issuecomment-616344895 and
+        #  - https://cryptography.io/en/latest/random-numbers/
         return int.from_bytes(os.urandom(16), byteorder="big")
 
     def _get_verifier(self) -> int:

--- a/homekit/crypto/srp.py
+++ b/homekit/crypto/srp.py
@@ -20,9 +20,9 @@
 Implements the Secure Remote Password (SRP) algorithm. More information can be found on
 https://tools.ietf.org/html/rfc5054. See HomeKit spec page 36 for adjustments imposed by Apple.
 """
-import crypt
 import math
 import hashlib
+import os
 
 
 class Srp:
@@ -60,8 +60,7 @@ E0FD108E4B82D120A93AD2CAFFFFFFFFFFFFFFFF''', 16)
 
         :return: the key as an integer
         """
-        private_key = crypt.mksalt(crypt.METHOD_SHA512)[3:].encode()
-        return int.from_bytes(private_key, "big")
+        return int.from_bytes(os.urandom(16), byteorder="big")
 
     def _calculate_k(self) -> int:
         # calculate k (see https://tools.ietf.org/html/rfc5054#section-2.5.3)
@@ -212,10 +211,7 @@ class SrpServer(Srp):
     @staticmethod
     def _create_salt() -> int:
         # generate random salt
-        salt = crypt.mksalt(crypt.METHOD_SHA512)[3:]
-        assert len(salt) == 16
-        salt_b = salt.encode()
-        return int.from_bytes(salt_b, "big")
+        return int.from_bytes(os.urandom(16), byteorder="big")
 
     def _get_verifier(self) -> int:
         hash_value = self._calculate_x()

--- a/requirements_windows.txt
+++ b/requirements_windows.txt
@@ -1,0 +1,8 @@
+zeroconf
+hkdf
+ed25519
+cryptography>=2.5
+coverage
+flake8
+pytest
+tlv8

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setuptools.setup(
         'hkdf',
         'ed25519',
         'cryptography>=2.5',
+        'tlv8',
     ],
     extras_require={
         'IP': ['zeroconf'],

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -79,6 +79,7 @@ class TestControllerIpUnpaired(unittest.TestCase):
               "unsuccessful_tries": 0
             }""".encode())
         cls.config_file.flush()
+        print('name', cls.config_file.name)
 
         # Make sure get_id() numbers are stable between tests
         model_mixin.id_counter = 0

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -96,11 +96,13 @@ class TestControllerIpUnpaired(unittest.TestCase):
         t = T(cls.httpd)
         t.start()
         time.sleep(10)
-        cls.controller_file = tempfile.NamedTemporaryFile()
+        cls.controller_file = tempfile.NamedTemporaryFile(delete=False)
+        cls.controller_file.close()
 
     def __init__(self, methodName='runTest'):
         unittest.TestCase.__init__(self, methodName)
-        self.controller_file = tempfile.NamedTemporaryFile()
+        self.controller_file = tempfile.NamedTemporaryFile(delete=False)
+        self.controller_file.close()
 
     @classmethod
     def tearDownClass(cls):
@@ -109,6 +111,7 @@ class TestControllerIpUnpaired(unittest.TestCase):
         cls.config_file.close()
         # manually remove temp file
         os.unlink(cls.config_file.name)
+        os.unlink(cls.controller_file.name)
 
     def setUp(self):
         self.controller = Controller()
@@ -184,7 +187,7 @@ class TestControllerIpPaired(unittest.TestCase):
             },
             "unsuccessful_tries": 0
         }""".encode())
-        cls.config_file.flush()
+        cls.config_file.close()
 
         # Make sure get_id() numbers are stable between tests
         model_mixin.id_counter = 0

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -159,7 +159,9 @@ class TestControllerIpUnpaired(unittest.TestCase):
 class TestControllerIpPaired(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config_file = tempfile.NamedTemporaryFile()
+        # prepare config file for paired accessory server, delete false for Windows, so we can close the file and open
+        # it for reading after that
+        cls.config_file = tempfile.NamedTemporaryFile(delete=False)
         cls.config_file.write("""{
             "accessory_ltpk": "7986cf939de8986f428744e36ed72d86189bea46b4dcdc8d9d79a3e4fceb92b9",
             "accessory_ltsk": "3d99f3e959a1f93af4056966f858074b2a1fdec1c5fd84a51ea96f9fa004156a",
@@ -220,7 +222,8 @@ class TestControllerIpPaired(unittest.TestCase):
     def tearDownClass(cls):
         cls.httpd.unpublish_device()
         cls.httpd.shutdown()
-        cls.config_file.close()
+        # manually remove temp file
+        os.unlink(cls.config_file.name)
 
     def setUp(self):
         self.controller = Controller()

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -18,6 +18,7 @@ import unittest
 import tempfile
 import threading
 import time
+import os
 
 from homekit import Controller
 from homekit import AccessoryServer
@@ -62,8 +63,9 @@ def set_value(new_value):
 class TestControllerIpUnpaired(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # prepare config file for unpaired accessory server
-        cls.config_file = tempfile.NamedTemporaryFile()
+        # prepare config file for unpaired accessory server, delete false for Windows, so we can close the file and open
+        # it for reading after that
+        cls.config_file = tempfile.NamedTemporaryFile(delete=False)
         cls.config_file.write("""{
               "accessory_ltpk": "7986cf939de8986f428744e36ed72d86189bea46b4dcdc8d9d79a3e4fceb92b9",
               "accessory_ltsk": "3d99f3e959a1f93af4056966f858074b2a1fdec1c5fd84a51ea96f9fa004156a",
@@ -78,8 +80,7 @@ class TestControllerIpUnpaired(unittest.TestCase):
               },
               "unsuccessful_tries": 0
             }""".encode())
-        cls.config_file.flush()
-        print('name', cls.config_file.name)
+        cls.config_file.close()
 
         # Make sure get_id() numbers are stable between tests
         model_mixin.id_counter = 0
@@ -106,6 +107,8 @@ class TestControllerIpUnpaired(unittest.TestCase):
         cls.httpd.unpublish_device()
         cls.httpd.shutdown()
         cls.config_file.close()
+        # manually remove temp file
+        os.unlink(cls.config_file.name)
 
     def setUp(self):
         self.controller = Controller()

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -200,7 +200,7 @@ class TestControllerIpPaired(unittest.TestCase):
         t = T(cls.httpd)
         t.start()
         time.sleep(5)
-        cls.controller_file = tempfile.NamedTemporaryFile()
+        cls.controller_file = tempfile.NamedTemporaryFile(delete=False)
         cls.controller_file.write("""{
             "alias": {
                 "Connection": "IP",
@@ -213,7 +213,7 @@ class TestControllerIpPaired(unittest.TestCase):
                 "iOSDeviceLTSK": "fa45f082ef87efc6c8c8d043d74084a3ea923a2253e323a7eb9917b4090c2fcc"
             }
         }""".encode())
-        cls.controller_file.flush()
+        cls.controller_file.close()
 
     def __init__(self, methodName='runTest'):
         unittest.TestCase.__init__(self, methodName)
@@ -224,6 +224,7 @@ class TestControllerIpPaired(unittest.TestCase):
         cls.httpd.shutdown()
         # manually remove temp file
         os.unlink(cls.config_file.name)
+        os.unlink(cls.controller_file.name)
 
     def setUp(self):
         self.controller = Controller()
@@ -465,16 +466,16 @@ class TestController(unittest.TestCase):
         controller_file.close()
 
     def test_load_pairings_unknown_type(self):
-        controller_file = tempfile.NamedTemporaryFile()
+        controller_file = tempfile.NamedTemporaryFile(delete=False)
         controller_file.write("""{
              "alias_unknown": {
                  "Connection": "UNKNOWN"
              }
          }""".encode())
-        controller_file.flush()
+        controller_file.close()
         self.controller.load_data(controller_file.name)
         self.assertEqual(0, len(self.controller.get_pairings()))
-        controller_file.close()
+        os.unlink(controller_file.name)
 
     def test_load_pairings_invalid_json(self):
         controller_file = tempfile.NamedTemporaryFile()

--- a/tests/serverdata_test.py
+++ b/tests/serverdata_test.py
@@ -16,6 +16,7 @@
 
 import unittest
 import json
+import os
 
 from homekit.accessoryserver import AccessoryServerData
 import tempfile
@@ -24,7 +25,7 @@ import tempfile
 class TestServerData(unittest.TestCase):
 
     def test_example2_1_1(self):
-        fp = tempfile.NamedTemporaryFile(mode='w')
+        fp = tempfile.NamedTemporaryFile(mode='w', delete=False)
         data = {
             'host_ip': '12.34.56.78',
             'host_port': 4711,
@@ -36,7 +37,7 @@ class TestServerData(unittest.TestCase):
             'unsuccessful_tries': 0
         }
         json.dump(data, fp)
-        fp.flush()
+        fp.close()
 
         hksd = AccessoryServerData(fp.name)
         self.assertEqual(hksd.accessory_pairing_id_bytes, b'12:34:56:78:90:AB')
@@ -45,3 +46,5 @@ class TestServerData(unittest.TestCase):
         hksd.set_accessory_keys(pk, sk)
         self.assertEqual(hksd.accessory_ltpk, pk)
         self.assertEqual(hksd.accessory_ltsk, sk)
+
+        os.unlink(fp.name)


### PR DESCRIPTION
With this PR, rudimentary support for Windows is added. The code was tested on Windows 10 and supports only IP based accessories:

Changes:
 - add windows to the automated tests with travis
 - fix the tests to work with windows (mostly stuff with files that may be open only once)
 - fix a bug in `homekit/accessoryserver.py` where the wrong variable was used in the error message
 - add `tlv8` to the list of install requirements in `setup.py`