### PR TITLE
Fix 189 get accessories fails for ble

### DIFF
--- a/homekit/accessoryserver.py
+++ b/homekit/accessoryserver.py
@@ -634,7 +634,6 @@ class AccessoryRequestHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
     def _get_accessories(self):
-
         result_bytes = self.server.accessories.to_accessory_and_service_list().encode()
         self.send_response(HttpStatusCodes.OK)
         self.send_header('Content-Type', 'application/hap+json')

--- a/homekit/controller/ble_impl/__init__.py
+++ b/homekit/controller/ble_impl/__init__.py
@@ -750,7 +750,7 @@ def read_characteristics(device):
         if s_data['iid']:
             a_data['services'].append(s_data)
 
-    logger.debug('data: %s', resolved_data)
+    logging.debug('data: %s', resolved_data)
 
     return resolved_data
 
@@ -776,7 +776,7 @@ def parse_sig_read_response(data, expected_tid):
     logger.debug('expected body length %d (got %d)', length, len(data[5:]))
 
     # parse tlvs and analyse information
-    tlv = tlv8.decode(data[5:])
+    tlv = tlv8.decode(bytes([int(a) for a in data[5:]]))
 
     description = ''
     characteristic_format = ''

--- a/tests/ble_controller_test.py
+++ b/tests/ble_controller_test.py
@@ -20,6 +20,7 @@ from unittest import mock
 import uuid
 import logging
 import tlv8
+import dbus
 
 from homekit.crypto.chacha20poly1305 import chacha20_aead_decrypt, chacha20_aead_encrypt
 from homekit import Controller
@@ -314,10 +315,14 @@ class Characteristic:
         self.values.append(value)
 
     def read_value(self):
+        # real world objects return a dbus.Array object here, this array contains dbus.Byte values.
+        # dbus.Array([dbus.Byte(2), ..., dbus.Byte(1)], signature=dbus.Signature('y'))
         if not self.values:
-            return b''
+            return dbus.Array(b'')
 
-        return self.values.pop(0)
+        val = [dbus.Byte(x) for x in self.values.pop(0)]
+        ar = dbus.Array(val)
+        return ar
 
 
 class ServiceInstanceId(Characteristic):

--- a/tests/ble_controller_test.py
+++ b/tests/ble_controller_test.py
@@ -20,7 +20,6 @@ from unittest import mock
 import uuid
 import logging
 import tlv8
-import dbus
 
 from homekit.crypto.chacha20poly1305 import chacha20_aead_decrypt, chacha20_aead_encrypt
 from homekit import Controller
@@ -36,6 +35,7 @@ from homekit import exceptions
 from homekit.tools import BLE_TRANSPORT_SUPPORTED
 
 if BLE_TRANSPORT_SUPPORTED:
+    import dbus
     from homekit.controller.ble_impl import CharacteristicInstanceID, AdditionalParameterTypes
     from homekit.protocol.opcodes import HapBleOpCodes
     from homekit.model.characteristics.characteristic_formats import BleCharacteristicFormats


### PR DESCRIPTION
Adds a Test for the issue to prevent regressions
Adds a fix for the issue by converting `dbus.Array` of `dbus.Byte` objects to `bytes`