### PR TITLE
Ignore unsupported pairings without failure

### DIFF
--- a/homekit/controller/controller.py
+++ b/homekit/controller/controller.py
@@ -32,6 +32,7 @@ from homekit.model.services.service_types import ServicesTypes
 from homekit.model.characteristics.characteristic_types import CharacteristicsTypes
 from homekit.protocol.opcodes import HapBleOpCodes
 from homekit.tools import IP_TRANSPORT_SUPPORTED, BLE_TRANSPORT_SUPPORTED
+from homekit.controller.tools import DummyPairing
 from homekit.controller.additional_pairing import AdditionalPairing
 
 if BLE_TRANSPORT_SUPPORTED:
@@ -256,7 +257,6 @@ class Controller(object):
             with open(filename, 'r') as input_fp:
                 data = json.load(input_fp)
                 for pairing_id in data:
-
                     if 'Connection' not in data[pairing_id]:
                         # This is a pre BLE entry in the file with the pairing data, hence it is for an IP based
                         # accessory. So we set the connection type (in case save data is used everything will be fine)
@@ -267,12 +267,18 @@ class Controller(object):
 
                     if data[pairing_id]['Connection'] == 'IP':
                         if not IP_TRANSPORT_SUPPORTED:
-                            raise TransportNotSupportedError('IP')
-                        self.pairings[pairing_id] = IpPairing(data[pairing_id])
+                            self.logger.debug(
+                                'setting pairing "%s" to dummy implementation because IP is not supported', pairing_id)
+                            self.pairings[pairing_id] = DummyPairing(data[pairing_id], 'IP')
+                        else:
+                            self.pairings[pairing_id] = IpPairing(data[pairing_id])
                     elif data[pairing_id]['Connection'] == 'BLE':
                         if not BLE_TRANSPORT_SUPPORTED:
-                            raise TransportNotSupportedError('BLE')
-                        self.pairings[pairing_id] = BlePairing(data[pairing_id], self.ble_adapter)
+                            self.logger.debug(
+                                'setting pairing "%s" to dummy implementation because BLE is not supported', pairing_id)
+                            self.pairings[pairing_id] = DummyPairing(data[pairing_id], 'BLE')
+                        else:
+                            self.pairings[pairing_id] = BlePairing(data[pairing_id], self.ble_adapter)
                     elif data[pairing_id]['Connection'] == 'ADDITIONAL_PAIRING':
                         self.pairings[pairing_id] = AdditionalPairing(data[pairing_id])
                     else:

--- a/homekit/controller/controller.py
+++ b/homekit/controller/controller.py
@@ -32,7 +32,7 @@ from homekit.model.services.service_types import ServicesTypes
 from homekit.model.characteristics.characteristic_types import CharacteristicsTypes
 from homekit.protocol.opcodes import HapBleOpCodes
 from homekit.tools import IP_TRANSPORT_SUPPORTED, BLE_TRANSPORT_SUPPORTED
-from homekit.controller.tools import DummyPairing
+from homekit.controller.tools import NotSupportedPairing
 from homekit.controller.additional_pairing import AdditionalPairing
 
 if BLE_TRANSPORT_SUPPORTED:
@@ -247,7 +247,9 @@ class Controller(object):
 
     def load_data(self, filename):
         """
-        Loads the pairing data of the controller from a file.
+        Loads the pairing data of the controller from a file. If the connection type of a pairing is currently not
+        supported by the python environment (e.g. because of missing modules for BLE), an instance of
+        `NotSupportedPairing` is used. By this no pairings are lost during a `load_data`/`save_data` cycle.
 
         :param filename: the file name of the pairing data
         :raises ConfigLoadingError: if the config could not be loaded. The reason is given in the message.
@@ -269,14 +271,14 @@ class Controller(object):
                         if not IP_TRANSPORT_SUPPORTED:
                             self.logger.debug(
                                 'setting pairing "%s" to dummy implementation because IP is not supported', pairing_id)
-                            self.pairings[pairing_id] = DummyPairing(data[pairing_id], 'IP')
+                            self.pairings[pairing_id] = NotSupportedPairing(data[pairing_id], 'IP')
                         else:
                             self.pairings[pairing_id] = IpPairing(data[pairing_id])
                     elif data[pairing_id]['Connection'] == 'BLE':
                         if not BLE_TRANSPORT_SUPPORTED:
                             self.logger.debug(
                                 'setting pairing "%s" to dummy implementation because BLE is not supported', pairing_id)
-                            self.pairings[pairing_id] = DummyPairing(data[pairing_id], 'BLE')
+                            self.pairings[pairing_id] = NotSupportedPairing(data[pairing_id], 'BLE')
                         else:
                             self.pairings[pairing_id] = BlePairing(data[pairing_id], self.ble_adapter)
                     elif data[pairing_id]['Connection'] == 'ADDITIONAL_PAIRING':

--- a/homekit/controller/tools.py
+++ b/homekit/controller/tools.py
@@ -147,6 +147,44 @@ class AbstractPairing(abc.ABC):
         pass
 
 
+class DummyPairing(AbstractPairing):
+    def __init__(self, pairing_data, connection_type):
+        self.pairing_data = pairing_data
+        self.connection_type = connection_type
+
+    def close(self):
+        pass
+
+    def list_accessories_and_characteristics(self):
+        raise NotImplementedError(
+            'Connection type "{}" is not supported in this setup!'.format(self.connection_type))
+
+    def list_pairings(self):
+        raise NotImplementedError(
+            'Connection type "{}" is not supported in this setup!'.format(self.connection_type))
+
+    def get_characteristics(self, characteristics, include_meta=False, include_perms=False, include_type=False,
+                            include_events=False):
+        raise NotImplementedError(
+            'Connection type "{}" is not supported in this setup!'.format(self.connection_type))
+
+    def put_characteristics(self, characteristics, do_conversion=False):
+        raise NotImplementedError(
+            'Connection type "{}" is not supported in this setup!'.format(self.connection_type))
+
+    def get_events(self, characteristics, callback_fun, max_events=-1, max_seconds=-1):
+        raise NotImplementedError(
+            'Connection type "{}" is not supported in this setup!'.format(self.connection_type))
+
+    def identify(self):
+        raise NotImplementedError(
+            'Connection type "{}" is not supported in this setup!'.format(self.connection_type))
+
+    def add_pairing(self, additional_controller_pairing_identifier, ios_device_ltpk, permissions):
+        raise NotImplementedError(
+            'Connection type "{}" is not supported in this setup!'.format(self.connection_type))
+
+
 def check_convert_value(val, target_type):
     """
     Checks if the given value is of the given type or is convertible into the type. If the value is not convertible, a

--- a/homekit/controller/tools.py
+++ b/homekit/controller/tools.py
@@ -147,9 +147,12 @@ class AbstractPairing(abc.ABC):
         pass
 
 
-class DummyPairing(AbstractPairing):
+class NotSupportedPairing(AbstractPairing):
     """
-    Dummy implementation of a AbstractPairing handle Pairings in a configuration that might currently not be supported.
+    Implementation of `AbstractPairing` with no implemented functions but only for handling connection type and pairing
+    data. This is used in `Controller.load_data` if the connection type of the pairing is not supported (e.g. exchanging
+    a file with pairing data between linux (IP and BLE) and OS X (IP only). Without using this `DummyPairing` the
+    pairings would be lost on saving of the file.
     """
 
     def __init__(self, pairing_data, connection_type):

--- a/homekit/controller/tools.py
+++ b/homekit/controller/tools.py
@@ -148,6 +148,10 @@ class AbstractPairing(abc.ABC):
 
 
 class DummyPairing(AbstractPairing):
+    """
+    Dummy implementation of a AbstractPairing handle Pairings in a configuration that might currently not be supported.
+    """
+
     def __init__(self, pairing_data, connection_type):
         self.pairing_data = pairing_data
         self.connection_type = connection_type


### PR DESCRIPTION
This will allow to use pairing data files with unsupported connection types without loosing those pairings during a `load_data`/`save_data` cycle.