### PR TITLE
update pairing method to be in line with HomeKit ADK

### DIFF
--- a/homekit/protocol/methods.py
+++ b/homekit/protocol/methods.py
@@ -16,8 +16,9 @@ from enum import IntEnum
 
 
 class Methods(IntEnum):
-    # Methods (see table 4-4 page 60)
-    PairSetup = 1
+    # Methods (see open source HomeKit ADK, HAPPairingMethod (HAPPairing.h:56)
+    PairSetup = 0
+    PairSetupWithAuth = 1
     PairVerify = 2
     AddPairing = 3
     RemovePairing = 4


### PR DESCRIPTION
In R17, `PairSetup` is defined by 0, whereas `PairSetupWithAuth` is defined with 1. The main difference lies in the necessary hardware: `PairSetupWithAuth` needs an Apple co-processor for the authentication in pairing step M4.

The problem arouse as I was trying to use homekit_python to track down problems with the pairing of a custom accessory which is currently developed. This helped me to track down the issue with the newer definition.