### PR TITLE
Fix #223: Cache characteristics on BlePairing-initialization

### DIFF
--- a/homekit/controller/ble_impl/__init__.py
+++ b/homekit/controller/ble_impl/__init__.py
@@ -75,7 +75,6 @@ class BlePairing(AbstractPairing):
         #   on pairing. Note that e.g. BleSession expects proper defined pairing_data.
         self.list_accessories_and_characteristics()
 
-
     def close(self):
         pass
 

--- a/homekit/controller/ble_impl/__init__.py
+++ b/homekit/controller/ble_impl/__init__.py
@@ -69,6 +69,13 @@ class BlePairing(AbstractPairing):
         self.pairing_data = pairing_data
         self.session = None
 
+        # if necessary, add the accessory list and characteristics to the object
+        #   see https://github.com/jlusiardi/homekit_python/issues/223
+        #   This behaviour is similar to Apples Home app, which caches all services and characteristics
+        #   on pairing. Note that e.g. BleSession expects proper defined pairing_data.
+        self.list_accessories_and_characteristics()
+
+
     def close(self):
         pass
 
@@ -432,6 +439,7 @@ class BleSession(object):
         self.c2a_key = None
         self.a2c_key = None
         self.device = None
+
         mac_address = self.pairing_data['AccessoryMAC']
 
         manager = DeviceManager(self.adapter)

--- a/homekit/controller/controller.py
+++ b/homekit/controller/controller.py
@@ -624,8 +624,11 @@ class Controller(object):
         Remove a pairing between the controller and the accessory. The pairing data is delete on both ends, on the
         accessory and the controller.
 
-        Important: no automatic saving of the pairing data is performed. If you don't do this, the accessory seems still
-            to be paired on the next start of the application.
+        Important:
+            - no automatic saving of the pairing data is performed. If you don't do this, the accessory seems still
+                to be paired on the next start of the application.
+            - due to the deletion of the pairing on both sides, calling this function will change the dictionary.
+                This may lead to errors in for-loops. If necessary, cache all keys before calling this function.
 
         :param alias: the controller's alias for the accessory
         :param pairingId: the pairing id to be removed

--- a/tests/ble_controller_test.py
+++ b/tests/ble_controller_test.py
@@ -760,7 +760,6 @@ class TestBLEController(unittest.TestCase):
                 m1.return_value = manager
                 m2.return_value = manager
                 c.perform_pairing_ble('test-pairing', '00:00:00:00:00', '111-11-111')
-                c.pairings['test-pairing'].list_accessories_and_characteristics()
                 self.assertEqual(len(device.peers), 1)
 
                 c.remove_pairing('test-pairing')


### PR DESCRIPTION
If necessary, all services and characteristics will be cached on pairing via BLE. This ensures that the pairing_data is in a valid state after initializing the pairing object (which is important for e.g. BleSession).

Note that this behavior is similar to the Apple Home app, which also caches all characteristics on pairing.