### PR TITLE
Do not create hex-string and rebuild byte string for TLV and data

### DIFF
--- a/homekit/controller/ble_impl/__init__.py
+++ b/homekit/controller/ble_impl/__init__.py
@@ -247,7 +247,7 @@ class BlePairing(AbstractPairing):
             return value.encode('UTF-8')
 
         if char_format == CharacteristicFormats.data or char_format == CharacteristicFormats.tlv8:
-            return value.hex().encode()
+            return value
 
         # from here only integer values of different sizes
         if char_format == CharacteristicFormats.int:


### PR DESCRIPTION
Since TLVs (and data) are defined on byte level, the values are destroyed
by converting them to string and back to bytes.

This solves issue #238.